### PR TITLE
Freed each stream after request in consumer fetch

### DIFF
--- a/src/Kafka/Consumer.php
+++ b/src/Kafka/Consumer.php
@@ -259,6 +259,7 @@ class Consumer
             $encoder = new \Kafka\Protocol\Encoder($conn);
             $encoder->fetchRequest($requestData);
             $streams[$connArr['key']] = $conn;
+            $this->client->freeStream($connArr['key']);
         }
 
         $fetch = new \Kafka\Protocol\Fetch\Topic($streams, $data);


### PR DESCRIPTION
Following the example below, the socket will not closed and not freed either. On the next $consumer->fetch(), it would have to open a new socket. I think we should free the socket so it can be reused. Please give me your thoughts?

```
$consumer = \Kafka\Consumer::getInstance('localhost:2181');

$consumer->setGroup('testgroup');
$consumer->setPartition('test', 0);
$consumer->setPartition('test6', 2, 10);
$result = $consumer->fetch();
foreach ($result as $topicName => $topic) {
    foreach ($topic as $partId => $partition) {
        var_dump($partition->getHighOffset());
        foreach ($partition as $message) {
            var_dump((string)$message);
        }
    }
}
```
