### PR TITLE
Fix demo code bug & socket write failure issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $producer->setLogger($logger);
 $producer->success(function($result) {
 	var_dump($result);
 });
-$producer->error(function($errorCode, $context) {
+$producer->error(function($errorCode) {
 		var_dump($errorCode);
 });
 $producer->send(true);

--- a/README_CH.md
+++ b/README_CH.md
@@ -75,7 +75,7 @@ $producer->setLogger($logger);
 $producer->success(function($result) {
 	var_dump($result);
 });
-$producer->error(function($errorCode, $context) {
+$producer->error(function($errorCode) {
 	var_dump($errorCode);
 });
 $producer->send(true);

--- a/src/Kafka/Socket.php
+++ b/src/Kafka/Socket.php
@@ -35,9 +35,10 @@ class Socket
     /**
      * max write socket buffer
      * fixed:send of 8192 bytes failed with errno=11 Resource temporarily
+     * fixed:'fwrite(): send of ???? bytes failed with errno=35 Resource temporarily unavailable'
      * unavailable error info
      */
-    const MAX_WRITE_BUFFER = 4096;
+    const MAX_WRITE_BUFFER = 2048;
 
     // }}}
     // {{{ members

--- a/src/Kafka/SocketSync.php
+++ b/src/Kafka/SocketSync.php
@@ -35,9 +35,10 @@ class SocketSync
     /**
      * max write socket buffer
      * fixed:send of 8192 bytes failed with errno=11 Resource temporarily
+     * fixed:'fwrite(): send of ???? bytes failed with errno=35 Resource temporarily unavailable'
      * unavailable error info
      */
-    const MAX_WRITE_BUFFER = 4096;
+    const MAX_WRITE_BUFFER = 2048;
 
     // }}}
     // {{{ members


### PR DESCRIPTION
1. Send large message failed. exception: 'fwrite(): send of 1912 bytes failed with errno=35 Resource temporarily unavailable'
I changed the write buffer to 2048, issue resolved.
```php
const MAX_WRITE_BUFFER = 2048;
```

2. Only one parameter for failure callback function. Or error will be thrown when running demo.
```php
if ($this->error) {
    call_user_func($this->error, $errorCode);
}
```