### PR TITLE
Implement compression properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,22 @@ jobs:
         apt:
           packages:
             - docker-ce
+      env: KAFKA_VERSION=0.9.0.1 KAFKA_COMPRESS=1
+      before_install:
+        - docker-compose up -d kafka-$KAFKA_VERSION
+        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+      script:
+        - sleep 10 # add some arbitrary time to ensure that kafka is running fine
+        - docker-compose exec kafka-$KAFKA_VERSION /opt/kafka_2.11-0.9.0.1/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
+        - docker-compose run -e KAFKA_BROKERS=kafka-$KAFKA_VERSION:9092 -e KAFKA_VERSION -e KAFKA_TOPIC=test -e KAFKA_COMPRESS test-runner
+
+    - stage: Functional tests
+      services:
+        - docker
+      addons:
+        apt:
+          packages:
+            - docker-ce
       env: KAFKA_VERSION=0.10.2.1
       before_install:
         - docker-compose up -d kafka-$KAFKA_VERSION
@@ -84,6 +100,24 @@ jobs:
         - sleep 10 # add some arbitrary time to ensure that kafka is running fine
         - docker-compose exec kafka-$KAFKA_VERSION /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
         - docker-compose run -e KAFKA_BROKERS=kafka-$KAFKA_VERSION:9092 -e KAFKA_VERSION -e KAFKA_TOPIC=test test-runner
+      after_script:
+        - docker-compose down
+
+    - stage: Functional tests
+      services:
+        - docker
+      addons:
+        apt:
+          packages:
+            - docker-ce
+      env: KAFKA_VERSION=0.10.2.1 KAFKA_COMPRESS=1
+      before_install:
+        - docker-compose up -d kafka-$KAFKA_VERSION
+        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+      script:
+        - sleep 10 # add some arbitrary time to ensure that kafka is running fine
+        - docker-compose exec kafka-$KAFKA_VERSION /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
+        - docker-compose run -e KAFKA_BROKERS=kafka-$KAFKA_VERSION:9092 -e KAFKA_VERSION -e KAFKA_TOPIC=test -e KAFKA_COMPRESS test-runner
       after_script:
         - docker-compose down
 
@@ -112,6 +146,24 @@ jobs:
         apt:
           packages:
             - docker-ce
+      env: KAFKA_VERSION=0.11.0.1 KAFKA_COMPRESS=1
+      before_install:
+        - docker-compose up -d kafka-$KAFKA_VERSION
+        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+      script:
+        - sleep 10 # add some arbitrary time to ensure that kafka is running fine
+        - docker-compose exec kafka-$KAFKA_VERSION /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
+        - docker-compose run -e KAFKA_BROKERS=kafka-$KAFKA_VERSION:9092 -e KAFKA_VERSION -e KAFKA_TOPIC=test -e KAFKA_COMPRESS test-runner
+      after_script:
+        - docker-compose down
+
+    - stage: Functional tests
+      services:
+        - docker
+      addons:
+        apt:
+          packages:
+            - docker-ce
       env: KAFKA_VERSION=1.0.0
       before_install:
         - docker-compose up -d kafka-$KAFKA_VERSION
@@ -120,6 +172,24 @@ jobs:
         - sleep 10 # add some arbitrary time to ensure that kafka is running fine
         - docker-compose exec kafka-$KAFKA_VERSION /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
         - docker-compose run -e KAFKA_BROKERS=kafka-$KAFKA_VERSION:9092 -e KAFKA_VERSION -e KAFKA_TOPIC=test test-runner
+      after_script:
+        - docker-compose down
+
+    - stage: Functional tests
+      services:
+        - docker
+      addons:
+        apt:
+          packages:
+            - docker-ce
+      env: KAFKA_VERSION=1.0.0 KAFKA_COMPRESS=1
+      before_install:
+        - docker-compose up -d kafka-$KAFKA_VERSION
+        - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+      script:
+        - sleep 10 # add some arbitrary time to ensure that kafka is running fine
+        - docker-compose exec kafka-$KAFKA_VERSION /opt/kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --create --partitions 3 --replication-factor 1 --topic test
+        - docker-compose run -e KAFKA_BROKERS=kafka-$KAFKA_VERSION:9092 -e KAFKA_VERSION -e KAFKA_TOPIC=test -e KAFKA_COMPRESS test-runner
       after_script:
         - docker-compose down
 

--- a/src/ConsumerConfig.php
+++ b/src/ConsumerConfig.php
@@ -4,6 +4,11 @@ namespace Kafka;
 /**
  * @method string|false ietGroupId()
  * @method array|false ietTopics()
+ * @method int getSessionTimeout()
+ * @method int getRebalanceTimeout()
+ * @method string getOffsetReset()
+ * @method int getMaxBytes()
+ * @method int getMaxWaitTime()
  */
 class ConsumerConfig extends Config
 {
@@ -17,79 +22,85 @@ class ConsumerConfig extends Config
     ];
 
     protected static $defaults = [
-        'groupId' => '',
-        'sessionTimeout' => 30000,
+        'groupId'          => '',
+        'sessionTimeout'   => 30000,
         'rebalanceTimeout' => 30000,
-        'topics' => [],
-        'offsetReset' => 'latest', // earliest
-        'maxBytes' => 65536, // 64kb
-        'maxWaitTime' => 100,
+        'topics'           => [],
+        'offsetReset'      => 'latest', // earliest
+        'maxBytes'         => 65536, // 64kb
+        'maxWaitTime'      => 100,
     ];
 
-    public function getGroupId()
+    public function getGroupId(): string
     {
         $groupId = trim($this->ietGroupId());
 
-        if ($groupId == false || $groupId == '') {
-            throw new \Kafka\Exception\Config('Get group id value is invalid, must set it not empty string');
+        if ($groupId === false || $groupId === '') {
+            throw new Exception\Config('Get group id value is invalid, must set it not empty string');
         }
 
         return $groupId;
     }
 
-    public function setGroupId($groupId)
+    public function setGroupId(string $groupId): void
     {
         $groupId = trim($groupId);
-        if ($groupId == false || $groupId == '') {
-            throw new \Kafka\Exception\Config('Set group id value is invalid, must set it not empty string');
+
+        if ($groupId === false || $groupId === '') {
+            throw new Exception\Config('Set group id value is invalid, must set it not empty string');
         }
+
         static::$options['groupId'] = $groupId;
     }
 
-    public function setSessionTimeout($sessionTimeout)
+    public function setSessionTimeout($sessionTimeout): void
     {
         if (! is_numeric($sessionTimeout) || $sessionTimeout < 1 || $sessionTimeout > 3600000) {
-            throw new \Kafka\Exception\Config('Set session timeout value is invalid, must set it 1 .. 3600000');
+            throw new Exception\Config('Set session timeout value is invalid, must set it 1 .. 3600000');
         }
+
         static::$options['sessionTimeout'] = $sessionTimeout;
     }
 
-    public function setRebalanceTimeout($rebalanceTimeout)
+    public function setRebalanceTimeout($rebalanceTimeout): void
     {
         if (! is_numeric($rebalanceTimeout) || $rebalanceTimeout < 1 || $rebalanceTimeout > 3600000) {
-            throw new \Kafka\Exception\Config('Set rebalance timeout value is invalid, must set it 1 .. 3600000');
+            throw new Exception\Config('Set rebalance timeout value is invalid, must set it 1 .. 3600000');
         }
+
         static::$options['rebalanceTimeout'] = $rebalanceTimeout;
     }
 
-    public function setOffsetReset($offsetReset)
+    public function setOffsetReset($offsetReset): void
     {
-        if (! in_array($offsetReset, ['latest', 'earliest'])) {
-            throw new \Kafka\Exception\Config('Set offset reset value is invalid, must set it `latest` or `earliest`');
+        if (! \in_array($offsetReset, ['latest', 'earliest'], true)) {
+            throw new Exception\Config('Set offset reset value is invalid, must set it `latest` or `earliest`');
         }
+
         static::$options['offsetReset'] = $offsetReset;
     }
 
-    public function getTopics()
+    public function getTopics(): array
     {
         $topics = $this->ietTopics();
 
         if (empty($topics)) {
-            throw new \Kafka\Exception\Config('Get consumer topics value is invalid, must set it not empty');
+            throw new Exception\Config('Get consumer topics value is invalid, must set it not empty');
         }
 
         return $topics;
     }
 
-    public function setTopics($topics)
+    public function setTopics(array $topics): void
     {
-        if (! is_array($topics) || empty($topics)) {
-            throw new \Kafka\Exception\Config('Set consumer topics value is invalid, must set it not empty array');
+        if (empty($topics)) {
+            throw new Exception\Config('Set consumer topics value is invalid, must set it not empty array');
         }
+
         static::$options['topics'] = $topics;
     }
 
-    public function setConsumeMode($mode)
+    public function setConsumeMode(int $mode): void
     {
         $this->runtimeOptions['consume_mode'] = $mode;
     }

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -5,7 +5,6 @@ use Amp\Loop;
 use Kafka\Broker;
 use Kafka\ProducerConfig;
 use Kafka\Protocol;
-use Kafka\Protocol\Produce;
 
 class Process
 {
@@ -189,6 +188,7 @@ class Process
         $broker      = Broker::getInstance();
         $requiredAck = ProducerConfig::getInstance()->getRequiredAck();
         $timeout     = ProducerConfig::getInstance()->getTimeout();
+        $compression = ProducerConfig::getInstance()->getCompression();
 
         // get send message
         // data struct
@@ -215,7 +215,7 @@ class Process
                 'required_ack' => $requiredAck,
                 'timeout'      => $timeout,
                 'data'         => $topicList,
-                'compression'  => Produce::COMPRESSION_NONE,
+                'compression'  => $compression,
             ];
 
             $this->debug("Send message start, params:" . json_encode($params));

--- a/src/Producer/State.php
+++ b/src/Producer/State.php
@@ -38,7 +38,7 @@ class State
         // instances clear
 
         // init requests
-        $config = \Kafka\ConsumerConfig::getInstance();
+        $config = \Kafka\ProducerConfig::getInstance();
 
         foreach ($this->requests as $request => $option) {
             switch ($request) {
@@ -80,7 +80,7 @@ class State
 
     public function succRun($key, $context = null)
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
+        $config = \Kafka\ProducerConfig::getInstance();
         $isAsyn = $config->getIsAsyn();
 
         if (! isset($this->callStatus[$key])) {

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -3,7 +3,6 @@ namespace Kafka\Producer;
 
 use Kafka\Broker;
 use Kafka\ProducerConfig;
-use Kafka\Protocol\Produce;
 use Kafka\Protocol\Protocol;
 
 class SyncProcess
@@ -28,6 +27,7 @@ class SyncProcess
         $broker      = Broker::getInstance();
         $requiredAck = ProducerConfig::getInstance()->getRequiredAck();
         $timeout     = ProducerConfig::getInstance()->getTimeout();
+        $compression = ProducerConfig::getInstance()->getCompression();
 
         // get send message
         // data struct
@@ -52,7 +52,7 @@ class SyncProcess
                 'required_ack' => $requiredAck,
                 'timeout'      => $timeout,
                 'data'         => $topicList,
-                'compression'  => Produce::COMPRESSION_NONE,
+                'compression'  => $compression,
             ];
 
             $this->debug("Send message start, params:" . json_encode($params));

--- a/src/ProducerConfig.php
+++ b/src/ProducerConfig.php
@@ -1,55 +1,86 @@
 <?php
 namespace Kafka;
 
+use Kafka\Protocol\Produce;
+
+/**
+ * @method int getRequestTimeout()
+ * @method int getProduceInterval()
+ * @method int getTimeout()
+ * @method int getRequiredAck()
+ * @method bool getIsAsyn()
+ * @method int getCompression()
+ */
 class ProducerConfig extends Config
 {
     use SingletonTrait;
 
-    protected static $defaults = [
-        'requiredAck' => 1,
-        'timeout' => 5000,
-        'isAsyn' => false,
-        'requestTimeout' => 6000,
-        'produceInterval' => 100,
+    private const COMPRESSION_OPTIONS = [
+        Produce::COMPRESSION_NONE,
+        Produce::COMPRESSION_GZIP,
+        Produce::COMPRESSION_SNAPPY,
     ];
 
-    public function setRequestTimeout($requestTimeout)
+    protected static $defaults = [
+        'requiredAck'     => 1,
+        'timeout'         => 5000,
+        'isAsyn'          => false,
+        'requestTimeout'  => 6000,
+        'produceInterval' => 100,
+        'compression'     => Protocol\Protocol::COMPRESSION_NONE,
+    ];
+
+    public function setRequestTimeout($requestTimeout): void
     {
         if (! is_numeric($requestTimeout) || $requestTimeout < 1 || $requestTimeout > 900000) {
-            throw new \Kafka\Exception\Config('Set request timeout value is invalid, must set it 1 .. 900000');
+            throw new Exception\Config('Set request timeout value is invalid, must set it 1 .. 900000');
         }
+
         static::$options['requestTimeout'] = $requestTimeout;
     }
 
-    public function setProduceInterval($produceInterval)
+    public function setProduceInterval($produceInterval): void
     {
         if (! is_numeric($produceInterval) || $produceInterval < 1 || $produceInterval > 900000) {
-            throw new \Kafka\Exception\Config('Set produce interval timeout value is invalid, must set it 1 .. 900000');
+            throw new Exception\Config('Set produce interval timeout value is invalid, must set it 1 .. 900000');
         }
+
         static::$options['produceInterval'] = $produceInterval;
     }
 
-    public function setTimeout($timeout)
+    public function setTimeout($timeout): void
     {
         if (! is_numeric($timeout) || $timeout < 1 || $timeout > 900000) {
-            throw new \Kafka\Exception\Config('Set timeout value is invalid, must set it 1 .. 900000');
+            throw new Exception\Config('Set timeout value is invalid, must set it 1 .. 900000');
         }
+
         static::$options['timeout'] = $timeout;
     }
 
-    public function setRequiredAck($requiredAck)
+    public function setRequiredAck($requiredAck): void
     {
         if (! is_numeric($requiredAck) || $requiredAck < -1 || $requiredAck > 1000) {
-            throw new \Kafka\Exception\Config('Set required ack value is invalid, must set it -1 .. 1000');
+            throw new Exception\Config('Set required ack value is invalid, must set it -1 .. 1000');
         }
+
         static::$options['requiredAck'] = $requiredAck;
     }
 
-    public function setIsAsyn($asyn)
+    public function setIsAsyn($asyn): void
     {
         if (! is_bool($asyn)) {
-            throw new \Kafka\Exception\Config('Set isAsyn value is invalid, must set it bool value');
+            throw new Exception\Config('Set isAsyn value is invalid, must set it bool value');
         }
+
         static::$options['isAsyn'] = $asyn;
+    }
+
+    public function setCompression(int $compression): void
+    {
+        if (! \in_array($compression, self::COMPRESSION_OPTIONS, true)) {
+            throw new Exception\Config('Compression must be one the Kafka\Protocol\Produce::COMPRESSION_* constants');
+        }
+
+        static::$options['compression'] = $compression;
     }
 }

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -202,7 +202,7 @@ class Fetch extends Protocol
             $keyRet  = $this->decodeString(substr($data, $offset), self::BIT_B32);
             $offset += $keyRet['length'];
 
-            $valueRet = $this->decodeString(substr($data, $offset), self::BIT_B32, $attr);
+            $valueRet = $this->decodeString(substr($data, $offset), self::BIT_B32, $attr & Produce::COMPRESSION_CODEC_MASK);
             $offset  += $valueRet['length'];
 
             if ($offset !== $messageSize) {

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -157,7 +157,7 @@ class Fetch extends Protocol
         $offset     += 4;
         $ret         = $this->decodeMessage(substr($data, $offset), $messageSize);
 
-        if (! is_array($ret) && $ret == false) {
+        if ($ret === null) {
             return null;
         }
 

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -85,12 +85,8 @@ class Fetch extends Protocol
 
         $messages = [];
 
-        if ($offset < strlen($data) && $messageSetSize) {
-            $messages = $this->decodeMessageSetArray(
-                substr($data, $offset, $messageSetSize),
-                [$this, 'decodeMessageSet'],
-                $messageSetSize
-            );
+        if ($offset < \strlen($data) && $messageSetSize) {
+            $messages = $this->decodeMessageSetArray(substr($data, $offset, $messageSetSize), $messageSetSize);
 
             $offset += $messages['length'];
         }
@@ -107,14 +103,14 @@ class Fetch extends Protocol
         ];
     }
 
-    protected function decodeMessageSetArray(string $data, callable $func, ?int $messageSetSize = null): array
+    protected function decodeMessageSetArray(string $data, int $messageSetSize): array
     {
         $offset = 0;
         $result = [];
 
-        while ($offset < strlen($data)) {
-            $value = substr($data, $offset);
-            $ret   = $messageSetSize !== null ? $func($value, $messageSetSize) : $func($value);
+        while ($offset < \strlen($data)) {
+            $value = \substr($data, $offset);
+            $ret   = $this->decodeMessageSet($value);
 
             if ($ret === null) {
                 break;

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -124,8 +124,15 @@ class Fetch extends Protocol
                 continue;
             }
 
-            $offset  += $ret['length'];
-            $result[] = $ret['data'];
+            $offset += $ret['length'];
+
+            if (($ret['data']['message']['attr'] & Produce::COMPRESSION_CODEC_MASK) === Produce::COMPRESSION_NONE) {
+                $result[] = $ret['data'];
+                continue;
+            }
+
+            $innerMessages = $this->decodeMessageSetArray($ret['data']['message']['value'], $ret['length']);
+            $result        = \array_merge($result, $innerMessages['data']);
         }
 
         if ($offset < $messageSetSize) {

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -43,7 +43,7 @@ class Fetch extends Protocol
             $offset      += 4;
         }
 
-        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'fetchTopic'], $version);
+        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'fetchTopic']);
         $offset += $topics['length'];
 
         return [
@@ -52,13 +52,13 @@ class Fetch extends Protocol
         ];
     }
 
-    protected function fetchTopic(string $data, string $version): array
+    protected function fetchTopic(string $data): array
     {
         $offset    = 0;
         $topicInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
         $offset   += $topicInfo['length'];
 
-        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'fetchPartition'], $version);
+        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'fetchPartition']);
         $offset    += $partitions['length'];
 
         return [
@@ -70,7 +70,7 @@ class Fetch extends Protocol
         ];
     }
 
-    protected function fetchPartition(string $data, string $version): array
+    protected function fetchPartition(string $data): array
     {
         $offset              = 0;
         $partitionId         = self::unpack(self::BIT_B32, substr($data, $offset, 4));

--- a/src/Protocol/Produce.php
+++ b/src/Protocol/Produce.php
@@ -11,7 +11,7 @@ class Produce extends Protocol
      * Specifies the mask for the compression code. 3 bits to hold the compression codec.
      * 0 is reserved to indicate no compression
      */
-    private const COMPRESSION_CODEC_MASK = 0x07;
+    public const COMPRESSION_CODEC_MASK = 0x07;
 
     /**
      * Specify the mask of timestamp type: 0 for CreateTime, 1 for LogAppendTime.

--- a/src/Protocol/Produce.php
+++ b/src/Protocol/Produce.php
@@ -46,11 +46,10 @@ class Produce extends Protocol
         $data  .= self::encodeArray(
             $payloads['data'],
             [$this, 'encodeProduceTopic'],
-            self::COMPRESSION_NONE
+            $payloads['compression'] ?? self::COMPRESSION_NONE
         );
-        $data   = self::encodeString($header . $data, self::PACK_INT32);
 
-        return $data;
+        return self::encodeString($header . $data, self::PACK_INT32);
     }
 
     public function decode(string $data): array

--- a/tests/Base/ConsumerConfigTest.php
+++ b/tests/Base/ConsumerConfigTest.php
@@ -1,428 +1,278 @@
 <?php
+
 namespace KafkaTest\Base;
 
-class ConsumerConfigTest extends \PHPUnit\Framework\TestCase
+use Kafka\ConsumerConfig;
+
+final class ConsumerConfigTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var ConsumerConfig
+     */
+    private $config;
 
     /**
-     * setDown
-     *
-     * @access public
-     * @return void
+     * @before
      */
-    public function tearDown()
+    public function configureInstance(): void
     {
-        \Kafka\ConsumerConfig::getInstance()->clear();
+        $this->config = ConsumerConfig::getInstance();
     }
 
     /**
-     * testDefaultConfig
-     *
-     * @access public
-     * @return void
+     * @after
      */
-    public function testDefaultConfig()
+    public function cleanUpInstance(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $this->assertEquals($config->getClientId(), 'kafka-php');
-        $this->assertEquals($config->getSessionTimeout(), 30000);
-        $this->assertFalse($config->setValidKey('xxx', '222'));
-        $this->assertFalse($config->getValidKey());
-        $config->setValidKey('222');
-        $this->assertEquals($config->getValidKey(), '222');
+        ConsumerConfig::getInstance()->clear();
+    }
+
+    public function testDefaultConfig(): void
+    {
+        self::assertSame($this->config->getClientId(), 'kafka-php');
+        self::assertSame($this->config->getSessionTimeout(), 30000);
+
+        self::assertFalse($this->config->setValidKey('xxx', '222'));
+        self::assertFalse($this->config->getValidKey());
+
+        $this->config->setValidKey('222');
+        self::assertSame($this->config->getValidKey(), '222');
+    }
+
+    public function testSetClientId(): void
+    {
+        $this->config->setClientId('kafka-php1');
+
+        self::assertSame($this->config->getClientId(), 'kafka-php1');
     }
 
     /**
-     * testSetClientId
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetClientId()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setClientId('kafka-php1');
-        $this->assertEquals($config->getClientId(), 'kafka-php1');
-    }
-
-    /**
-     * testSetClientIdEmpty
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set clientId value is invalid, must is not empty string.
-     * @access public
-     * @return void
      */
-    public function testSetClientIdEmpty()
+    public function testSetClientIdEmpty(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setClientId('');
+        $this->config->setClientId('');
+    }
+
+    public function testSetBrokerVersion(): void
+    {
+        $this->config->setBrokerVersion('0.9.0.1');
+
+        self::assertSame($this->config->getBrokerVersion(), '0.9.0.1');
     }
 
     /**
-     * testSetBrokerVersion
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetBrokerVersion()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setBrokerVersion('0.9.0.1');
-        $this->assertEquals($config->getBrokerVersion(), '0.9.0.1');
-    }
-
-    /**
-     * testSetBrokerVersionEmpty
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set broker version value is invalid, must is not empty string and gt 0.8.0.
-     * @access public
-     * @return void
      */
-    public function testSetBrokerVersionEmpty()
+    public function testSetBrokerVersionEmpty(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setBrokerVersion('');
+        $this->config->setBrokerVersion('');
     }
 
     /**
-     * testSetBrokerVersionValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set broker version value is invalid, must is not empty string and gt 0.8.0.
-     * @access public
-     * @return void
      */
-    public function testSetBrokerVersionValid()
+    public function testSetBrokerVersionInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setBrokerVersion('0.1');
+        $this->config->setBrokerVersion('0.1');
+    }
+
+    public function testSetMetadataBrokerList(): void
+    {
+        $this->config->setMetadataBrokerList(' 127.0.0.1:9192,127.0.0.1:9292'); // with whitespace to ensure that the list is trimmed
+
+        self::assertSame($this->config->getMetadataBrokerList(), '127.0.0.1:9192,127.0.0.1:9292');
     }
 
     /**
-     * testSetMetadataBrokerList
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetMetadataBrokerList()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataBrokerList('127.0.0.1:9192,127.0.0.1:9292');
-        $this->assertEquals($config->getMetadataBrokerList(), '127.0.0.1:9192,127.0.0.1:9292');
-    }
-
-    /**
-     * testSetMetadataBrokerListEmpty
-     *
      * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set broker list value is invalid, must is not empty string
-     * @access public
-     * @return void
+     * @expectedExceptionMessage Broker list must be a comma-separated list of brokers (format: "host:port"), with at least one broker
      */
-    public function testSetMetadataBrokerListEmpty()
+    public function testSetMetadataBrokerListEmpty(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataBrokerList('');
+        $this->config->setMetadataBrokerList('');
     }
 
     /**
-     * testSetMetadataBrokerListEmpty
-     *
      * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set broker list value is invalid, must is not empty string
-     * @access public
-     * @return void
+     * @expectedExceptionMessage Broker list must be a comma-separated list of brokers (format: "host:port"), with at least one broker
      */
-    public function testSetMetadataBrokerListEmpty1()
+    public function testSetMetadataBrokerListEmpty1(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataBrokerList(',');
+        $this->config->setMetadataBrokerList(',');
     }
 
     /**
-     * testSetMetadataBrokerListEmpty2
-     *
      * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set broker list value is invalid, must is not empty string
-     * @access public
-     * @return void
+     * @expectedExceptionMessage Broker list must be a comma-separated list of brokers (format: "host:port"), with at least one broker
      */
-    public function testSetMetadataBrokerListEmpty2()
+    public function testSetMetadataBrokerListEmpty2(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataBrokerList('127.0.0.1: , : ');
+        $this->config->setMetadataBrokerList('127.0.0.1: , : ');
+    }
+
+    public function testSetGroupId(): void
+    {
+        $this->config->setGroupId('test');
+
+        self::assertSame($this->config->getGroupId(), 'test');
     }
 
     /**
-     * testSetGroupId
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetGroupId()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setGroupId('test');
-        $this->assertEquals($config->getGroupId(), 'test');
-    }
-
-    /**
-     * testSetGroupIdEmpty
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set group id value is invalid, must set it not empty string
-     * @access public
-     * @return void
      */
-    public function testSetGroupIdEmpty()
+    public function testSetGroupIdEmpty(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setGroupId('');
+        $this->config->setGroupId('');
     }
 
     /**
-     * testGetGroupIdEmpty
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Get group id value is invalid, must set it not empty string
-     * @access public
-     * @return void
      */
-    public function testGetGroupIdEmpty()
+    public function testGetGroupIdEmpty(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->getGroupId();
+        $this->config->getGroupId();
+    }
+
+    public function testSetSessionTimeout(): void
+    {
+        $this->config->setSessionTimeout(2000);
+
+        self::assertSame($this->config->getSessionTimeout(), 2000);
     }
 
     /**
-     * testSetSessionTimeout
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetSessionTimeout()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setSessionTimeout(2000);
-        $this->assertEquals($config->getSessionTimeout(), 2000);
-    }
-
-    /**
-     * testSetSessionTimeoutValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set session timeout value is invalid, must set it 1 .. 3600000
-     * @access public
-     * @return void
      */
-    public function testSetSessionTimeoutValid()
+    public function testSetSessionTimeoutInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setSessionTimeout('-1');
+        $this->config->setSessionTimeout('-1');
+    }
+
+    public function testSetRebalanceTimeout(): void
+    {
+        $this->config->setRebalanceTimeout(2000);
+
+        self::assertSame($this->config->getRebalanceTimeout(), 2000);
     }
 
     /**
-     * testSetRebalanceTimeout
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetRebalanceTimeout()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setRebalanceTimeout(2000);
-        $this->assertEquals($config->getRebalanceTimeout(), 2000);
-    }
-
-    /**
-     * testSetRebalanceTimeoutValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set rebalance timeout value is invalid, must set it 1 .. 3600000
-     * @access public
-     * @return void
      */
-    public function testSetRebalanceTimeoutValid()
+    public function testSetRebalanceTimeoutInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setRebalanceTimeout('-1');
+        $this->config->setRebalanceTimeout('-1');
+    }
+
+    public function testSetOffsetReset(): void
+    {
+        $this->config->setOffsetReset('earliest');
+
+        self::assertSame($this->config->getOffsetReset(), 'earliest');
     }
 
     /**
-     * testSetOffsetReset
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetOffsetReset()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setOffsetReset('earliest');
-        $this->assertEquals($config->getOffsetReset(), 'earliest');
-    }
-
-    /**
-     * testSetOffsetResetValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set offset reset value is invalid, must set it `latest` or `earliest`
-     * @access public
-     * @return void
      */
-    public function testSetOffsetResetValid()
+    public function testSetOffsetResetInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setOffsetReset('xxxx');
+        $this->config->setOffsetReset('xxxx');
+    }
+
+    public function testSetTopics(): void
+    {
+        $this->config->setTopics(['test']);
+
+        self::assertSame($this->config->getTopics(), ['test']);
     }
 
     /**
-     * testSetTopics
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetTopics()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setTopics(['test']);
-        $this->assertEquals($config->getTopics(), ['test']);
-    }
-
-    /**
-     * testSetTopicsEmpty
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set consumer topics value is invalid, must set it not empty array
-     * @access public
-     * @return void
      */
-    public function testSetTopicsEmpty()
+    public function testSetTopicsEmpty(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setTopics('');
+        $this->config->setTopics([]);
     }
 
     /**
-     * testGetTopicsEmpty
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Get consumer topics value is invalid, must set it not empty
-     * @access public
-     * @return void
      */
-    public function testGetTopicsEmpty()
+    public function testGetTopicsEmpty(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->getTopics();
+        $this->config->getTopics();
+    }
+
+    public function testSetMessageMaxBytes(): void
+    {
+        $this->config->setMessageMaxBytes(1011);
+
+        self::assertSame($this->config->getMessageMaxBytes(), 1011);
     }
 
     /**
-     * testSetMessageMaxBytes
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetMessageMaxBytes()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMessageMaxBytes(1011);
-        $this->assertEquals($config->getMessageMaxBytes(), 1011);
-    }
-
-    /**
-     * testSetMessageMaxBytesValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set message max bytes value is invalid, must set it 1000 .. 1000000000
-     * @access public
-     * @return void
      */
-    public function testSetMessageMaxBytesValid()
+    public function testSetMessageMaxBytesInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMessageMaxBytes('999');
+        $this->config->setMessageMaxBytes('999');
+    }
+
+    public function testSetMetadataRequestTimeoutMs(): void
+    {
+        $this->config->setMetadataRequestTimeoutMs(1011);
+
+        self::assertSame($this->config->getMetadataRequestTimeoutMs(), 1011);
     }
 
     /**
-     * testSetMetadataRequestTimeoutMs
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetMetadataRequestTimeoutMs()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataRequestTimeoutMs(1011);
-        $this->assertEquals($config->getMetadataRequestTimeoutMs(), 1011);
-    }
-
-    /**
-     * testSetMetadataRequestTimeoutMsValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set metadata request timeout value is invalid, must set it 10 .. 900000
-     * @access public
-     * @return void
      */
-    public function testSetMetadataRequestTimeoutMsValid()
+    public function testSetMetadataRequestTimeoutMsInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataRequestTimeoutMs('9');
+        $this->config->setMetadataRequestTimeoutMs('9');
+    }
+
+    public function testSetMetadataRefreshIntervalMs(): void
+    {
+        $this->config->setMetadataRefreshIntervalMs(1011);
+
+        self::assertSame($this->config->getMetadataRefreshIntervalMs(), 1011);
     }
 
     /**
-     * testSetMetadataRefreshIntervalMs
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetMetadataRefreshIntervalMs()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataRefreshIntervalMs(1011);
-        $this->assertEquals($config->getMetadataRefreshIntervalMs(), 1011);
-    }
-
-    /**
-     * testSetMetadataRefreshIntervalMsValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set metadata refresh interval value is invalid, must set it 10 .. 3600000
-     * @access public
-     * @return void
      */
-    public function testSetMetadataRefreshIntervalMsValid()
+    public function testSetMetadataRefreshIntervalMsInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataRefreshIntervalMs('9');
+        $this->config->setMetadataRefreshIntervalMs('9');
+    }
+
+    public function testSetMetadataMaxAgeMs(): void
+    {
+        $this->config->setMetadataMaxAgeMs(1011);
+
+        self::assertSame($this->config->getMetadataMaxAgeMs(), 1011);
     }
 
     /**
-     * testSetMetadataMaxAgeMs
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetMetadataMaxAgeMs()
-    {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataMaxAgeMs(1011);
-        $this->assertEquals($config->getMetadataMaxAgeMs(), 1011);
-    }
-
-    /**
-     * testSetMetadataMaxAgeMsValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set metadata max age value is invalid, must set it 1 .. 86400000
-     * @access public
-     * @return void
      */
-    public function testSetMetadataMaxAgeMsValid()
+    public function testSetMetadataMaxAgeMsInvalid(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
-        $config->setMetadataMaxAgeMs('86400001');
+        $this->config->setMetadataMaxAgeMs('86400001');
     }
 }

--- a/tests/Base/ProducerConfigTest.php
+++ b/tests/Base/ProducerConfigTest.php
@@ -1,350 +1,259 @@
 <?php
+
 namespace KafkaTest\Base;
 
-class ProducerConfigTest extends \PHPUnit\Framework\TestCase
+use Kafka\Config;
+use Kafka\ProducerConfig;
+use Kafka\Protocol\Produce;
+
+final class ProducerConfigTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var ProducerConfig
+     */
+    private $config;
 
     /**
-     * setDown
-     *
-     * @access public
-     * @return void
+     * @before
      */
-    public function tearDown()
+    public function configureInstance(): void
     {
-        \Kafka\ProducerConfig::getInstance()->clear();
+        $this->config = ProducerConfig::getInstance();
     }
 
     /**
-     * testSetRequestTimeout
-     *
-     * @access public
-     * @return void
+     * @after
      */
-    public function testSetRequestTimeout()
+    public function cleanUpInstance(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setRequestTimeout(1011);
-        $this->assertEquals($config->getRequestTimeout(), 1011);
+        ProducerConfig::getInstance()->clear();
+    }
+
+    public function testSetRequestTimeout(): void
+    {
+        $this->config->setRequestTimeout(1011);
+
+        self::assertSame($this->config->getRequestTimeout(), 1011);
     }
 
     /**
-     * testSetRequestTimeoutValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set request timeout value is invalid, must set it 1 .. 900000
-     * @access public
-     * @return void
      */
-    public function testSetRequestTimeoutValid()
+    public function testSetRequestTimeoutValid(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setRequestTimeout('-1');
+        $this->config->setRequestTimeout('-1');
+    }
+
+    public function testSetProduceInterval(): void
+    {
+        $this->config->setProduceInterval(1011);
+
+        self::assertSame($this->config->getProduceInterval(), 1011);
     }
 
     /**
-     * testSetProduceInterval
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetProduceInterval()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setProduceInterval(1011);
-        $this->assertEquals($config->getProduceInterval(), 1011);
-    }
-
-    /**
-     * testSetProduceIntervalValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set produce interval timeout value is invalid, must set it 1 .. 900000
-     * @access public
-     * @return void
      */
-    public function testSetProduceIntervalValid()
+    public function testSetProduceIntervalValid(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setProduceInterval('-1');
+        $this->config->setProduceInterval('-1');
+    }
+
+    public function testSetTimeout(): void
+    {
+        $this->config->setTimeout(1011);
+
+        self::assertSame($this->config->getTimeout(), 1011);
     }
 
     /**
-     * testSetTimeout
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetTimeout()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setTimeout(1011);
-        $this->assertEquals($config->getTimeout(), 1011);
-    }
-
-    /**
-     * testSetTimeoutValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set timeout value is invalid, must set it 1 .. 900000
-     * @access public
-     * @return void
      */
-    public function testSetTimeoutValid()
+    public function testSetTimeoutValid(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setTimeout('-1');
+        $this->config->setTimeout('-1');
+    }
+
+    public function testSetRequiredAck(): void
+    {
+        $this->config->setRequiredAck(1);
+        self::assertSame($this->config->getRequiredAck(), 1);
     }
 
     /**
-     * testSetRequiredAck
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetRequiredAck()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setRequiredAck(1);
-        $this->assertEquals($config->getRequiredAck(), 1);
-    }
-
-    /**
-     * testSetRequiredAckValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set required ack value is invalid, must set it -1 .. 1000
-     * @access public
-     * @return void
      */
-    public function testSetRequiredAckValid()
+    public function testSetRequiredAckValid(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setRequiredAck('-2');
+        $this->config->setRequiredAck('-2');
+    }
+
+    public function testSetIsAsyn(): void
+    {
+        $this->config->setIsAsyn(true);
+
+        $this->assertTrue($this->config->getIsAsyn());
     }
 
     /**
-     * testSetIsAsyn
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetIsAsyn()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setIsAsyn(true);
-        $this->assertTrue($config->getIsAsyn());
-    }
-
-    /**
-     * testSetIsAsynValid
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set isAsyn value is invalid, must set it bool value
-     * @access public
-     * @return void
      */
-    public function testSetIsAsynValid()
+    public function testSetIsAsynValid(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setIsAsyn('-2');
+        $this->config->setIsAsyn('-2');
     }
 
     /**
-     * testSetSslLocalCert
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set ssl local cert file is invalid
-     * @access public
-     * @return void
      */
-    public function testSetSslLocalCert()
+    public function testSetSslLocalCert(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setSslLocalCert('invalid_path');
+        $this->config->setSslLocalCert('invalid_path');
     }
 
     /**
-     * testSetSslLocalCert
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set ssl local cert file is invalid
-     * @access public
-     * @return void
      */
-    public function testSetSslLocalCertNotFile()
+    public function testSetSslLocalCertNotFile(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setSslLocalCert('/tmp');
+        $this->config->setSslLocalCert('/tmp');
+    }
+
+    public function testSetSslLocalCertValid(): void
+    {
+        $path = '/etc/passwd';
+        $this->config->setSslLocalCert($path);
+
+        self::assertSame($path, $this->config->getSslLocalCert());
     }
 
     /**
-     * testSetSslLocalCertValid
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetSslLocalCertValid()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $path   = '/etc/passwd';
-        $config->setSslLocalCert($path);
-        $this->assertEquals($path, $config->getSslLocalCert());
-    }
-
-    /**
-     * testSetSslLocalPk
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set ssl local private key file is invalid
-     * @access public
-     * @return void
      */
-    public function testSetSslLocalPk()
+    public function testSetSslLocalPk(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setSslLocalPk('invalid_path');
+        $this->config->setSslLocalPk('invalid_path');
+    }
+
+    public function testSetSslLocalPkValid(): void
+    {
+        $path = '/etc/passwd';
+        $this->config->setSslLocalPk($path);
+
+        self::assertSame($path, $this->config->getSslLocalPk());
     }
 
     /**
-     * testSetSslLocalPkValid
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetSslLocalPkValid()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $path   = '/etc/passwd';
-        $config->setSslLocalPk($path);
-        $this->assertEquals($path, $config->getSslLocalPk());
-    }
-
-    /**
-     * testSetSslCafile
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set ssl ca file is invalid
-     * @access public
-     * @return void
      */
-    public function testSetSslCafile()
+    public function testSetSslCafile(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setSslCafile('invalid_path');
+        $this->config->setSslCafile('invalid_path');
+    }
+
+    public function testSetSslCafileValid(): void
+    {
+        $path = '/etc/passwd';
+        $this->config->setSslCafile($path);
+
+        self::assertSame($path, $this->config->getSslCafile());
     }
 
     /**
-     * testSetSslCafile
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetSslCafileValid()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $path   = '/etc/passwd';
-        $config->setSslCafile($path);
-        $this->assertEquals($path, $config->getSslCafile());
-    }
-
-    /**
-     * testSetSaslKeytab
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set sasl gssapi keytab file is invalid
-     * @access public
-     * @return void
      */
-    public function testSetSaslKeytab()
+    public function testSetSaslKeytab(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setSaslKeytab('invalid_path');
+        $this->config->setSaslKeytab('invalid_path');
+    }
+
+    public function testSetSaslKeytabValid(): void
+    {
+        $path = '/etc/passwd';
+        $this->config->setSaslKeytab($path);
+
+        self::assertSame($path, $this->config->getSaslKeytab());
     }
 
     /**
-     * testSetSaslKeytab
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetSaslKeytabValid()
-    {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $path   = '/etc/passwd';
-        $config->setSaslKeytab($path);
-        $this->assertEquals($path, $config->getSaslKeytab());
-    }
-
-    /**
-     * testSetSecurityProtocol
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Invalid security protocol given.
-     * @access public
-     * @return void
      */
-    public function testSetSecurityProtocol()
+    public function testSetSecurityProtocol(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setSecurityProtocol('xxxx');
+        $this->config->setSecurityProtocol('xxxx');
+    }
+
+    public function testSetSecurityProtocolValid(): void
+    {
+        $protocol = Config::SECURITY_PROTOCOL_PLAINTEXT;
+        $this->config->setSecurityProtocol($protocol);
+
+        self::assertSame($protocol, $this->config->getSecurityProtocol());
     }
 
     /**
-     * testSetSecurityProtocol
-     *
-     * @access public
-     * @return void
-     */
-    public function testSetSecurityProtocolValid()
-    {
-        $config   = \Kafka\ProducerConfig::getInstance();
-        $protocol = \Kafka\Config::SECURITY_PROTOCOL_PLAINTEXT;
-        $config->setSecurityProtocol($protocol);
-        $this->assertEquals($protocol, $config->getSecurityProtocol());
-    }
-
-    /**
-     * testSetSaslMechanism
-     *
      * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Invalid security sasl mechanism given.
-     * @access public
-     * @return void
      */
-    public function testSetSaslMechanism()
+    public function testSetSaslMechanism(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
-        $config->setSaslMechanism('xxxx');
+        $this->config->setSaslMechanism('xxxx');
+    }
+
+    public function testSetSaslMechanismValid(): void
+    {
+        $mechanism = Config::SASL_MECHANISMS_GSSAPI;
+        $this->config->setSaslMechanism($mechanism);
+
+        self::assertSame($mechanism, $this->config->getSaslMechanism());
     }
 
     /**
-     * testSetSaslMechanism
-     *
-     * @access public
-     * @return void
+     * @test
      */
-    public function testSetSaslMechanismValid()
+    public function defaultValueForCompressionIsNull(): void
     {
-        $config    = \Kafka\ProducerConfig::getInstance();
-        $mechanism = \Kafka\Config::SASL_MECHANISMS_GSSAPI;
-        $config->setSaslMechanism($mechanism);
-        $this->assertEquals($mechanism, $config->getSaslMechanism());
+        self::assertSame(Produce::COMPRESSION_NONE, $this->config->getCompression());
     }
 
     /**
-     * testClear
-     *
-     * @access public
-     * @return void
+     * @test
      */
-    public function testClear()
+    public function compressionCanBeConfigured(): void
     {
-        $config    = \Kafka\ProducerConfig::getInstance();
-        $mechanism = \Kafka\Config::SASL_MECHANISMS_GSSAPI;
-        $config->setSaslMechanism($mechanism);
-        $this->assertEquals($mechanism, $config->getSaslMechanism());
-        $config->clear();
-        $this->assertEquals(\Kafka\Config::SASL_MECHANISMS_PLAIN, $config->getSaslMechanism());
+        $this->config->setCompression(Produce::COMPRESSION_GZIP);
+
+        self::assertSame(Produce::COMPRESSION_GZIP, $this->config->getCompression());
+    }
+
+    /**
+     * @test
+     */
+    public function compressionCanOnlyBeConfiguredUsingAValidOption(): void
+    {
+        $this->config->setCompression(Produce::COMPRESSION_GZIP);
+
+        self::assertSame(Produce::COMPRESSION_GZIP, $this->config->getCompression());
+    }
+
+    public function testClear(): void
+    {
+        $mechanism = Config::SASL_MECHANISMS_GSSAPI;
+        $this->config->setSaslMechanism($mechanism);
+        self::assertSame($mechanism, $this->config->getSaslMechanism());
+        $this->config->clear();
+
+        self::assertSame(Config::SASL_MECHANISMS_PLAIN, $this->config->getSaslMechanism());
     }
 }

--- a/tests/Functional/ProducerTest.php
+++ b/tests/Functional/ProducerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace KafkaTest\Functional;
 
 use Kafka\Consumer\StopStrategy\Callback;
+use Kafka\Protocol\Protocol;
 
 abstract class ProducerTest extends \PHPUnit\Framework\TestCase
 {
@@ -25,13 +26,19 @@ abstract class ProducerTest extends \PHPUnit\Framework\TestCase
     private $topic;
 
     /**
+     * @var bool
+     */
+    protected $compress;
+
+    /**
      * @before
      */
     public function prepareEnvironment(): void
     {
-        $this->version = getenv('KAFKA_VERSION');
-        $this->brokers = getenv('KAFKA_BROKERS');
-        $this->topic   = getenv('KAFKA_TOPIC');
+        $this->version  = getenv('KAFKA_VERSION');
+        $this->brokers  = getenv('KAFKA_BROKERS');
+        $this->topic    = getenv('KAFKA_TOPIC');
+        $this->compress = getenv('KAFKA_COMPRESS') === '1';
 
         if (! $this->version || ! $this->brokers || ! $this->topic) {
             self::markTestSkipped(
@@ -45,6 +52,10 @@ abstract class ProducerTest extends \PHPUnit\Framework\TestCase
         $config = \Kafka\ProducerConfig::getInstance();
         $config->setMetadataBrokerList($this->brokers);
         $config->setBrokerVersion($this->version);
+
+        if ($this->compress) {
+            $config->setCompression(Protocol::COMPRESSION_GZIP);
+        }
     }
 
     /**

--- a/tests/Protocol/FetchTest.php
+++ b/tests/Protocol/FetchTest.php
@@ -132,4 +132,167 @@ final class FetchTest extends \PHPUnit\Framework\TestCase
 
         self::assertJsonStringEqualsJsonString($expected, json_encode($test));
     }
+
+    public function testDecodeCompressedMessage(): void
+    {
+        $data     = '0000000000000001000474657374000000030000000200000000000000000005000000820000000000000004000000764f9bfc190101000001608f09f09dffffffff000000601f8b08000000000000006360800319c19722b68c400663423fe787b95051b6dce2745d0343280f242dd3f1c0b51d873a23288f09a44eace5820a0e75a6501e33485d86e99a9938d45940792c2075f55f455f615767680000f433673fc800000000000001000000000000000000030000006900000000000000020000005d2df3369e0101000001608f09f09dffffffff000000471f8b08000000000000006360800399ffcf4b0519810cc6847ece0f73a1a26cb9c5e9ba06c6501e485aa6bfb7711e0e7566501e1348dd8fae8d1c38d4990300959fec9d7800000000000000000000000000000000020000005c00000000000000010000005049f79c420101000001608f09f09dffffffff0000003a1f8b08000000000000006360800399c4e6079b18810cc6847ece0f73a1a26cb9c5e9ba0626501e485a46de680e3f0e759600085bf4ff50000000';
+        $expected = [
+            'throttleTime' => 0,
+            'topics'       => [
+                [
+                    'topicName'  => 'test',
+                    'partitions' => [
+                        [
+                            'partition'           => 2,
+                            'errorCode'           => 0,
+                            'highwaterMarkOffset' => 5,
+                            'messageSetSize'      => 130,
+                            'messages'            => [
+                                [
+                                    'offset'  => 0,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 300487741,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-01',
+                                    ],
+                                ],
+                                [
+                                    'offset'  => 1,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 2296399239,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-02',
+                                    ],
+                                ],
+                                [
+                                    'offset'  => 2,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 377802788,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-05',
+                                    ],
+                                ],
+                                [
+                                    'offset'  => 3,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 1748348057,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-08',
+                                    ],
+                                ],
+                                [
+                                    'offset'  => 4,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 2146768362,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-10',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'partition'           => 1,
+                            'errorCode'           => 0,
+                            'highwaterMarkOffset' => 3,
+                            'messageSetSize'      => 105,
+                            'messages'            => [
+                                [
+                                    'offset'  => 0,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 4293358865,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-03',
+                                    ],
+                                ],
+                                [
+                                    'offset'  => 1,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 2408415646,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-06',
+                                    ],
+                                ],
+                                [
+                                    'offset'  => 2,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 4169838856,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-07',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'partition'           => 0,
+                            'errorCode'           => 0,
+                            'highwaterMarkOffset' => 2,
+                            'messageSetSize'      => 92,
+                            'messages'            => [
+                                [
+                                    'offset'  => 0,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 1636032690,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-04',
+                                    ],
+                                ],
+                                [
+                                    'offset'  => 1,
+                                    'size'    => 28,
+                                    'message' => [
+                                        'crc'       => 523410447,
+                                        'magic'     => 1,
+                                        'attr'      => 0,
+                                        'timestamp' => 1514228281501,
+                                        'key'       => '',
+                                        'value'     => 'msg-09',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $test = $this->fetch->decode(\hex2bin($data));
+
+        self::assertEquals($expected, $test);
+    }
 }


### PR DESCRIPTION
This PR fixes the creation and parsing of compressed message sets, making the library work follow the [Kafka protocol](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Messagesets) regarding that functionality.

@nmred some other small fixes are included I can extract them to a different PR to make it easier to review. I really recommend you to review this commit by commit