### PR TITLE
Fix variable check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
-        - ./vendor/bin/infection --min-msi=49 --min-covered-msi=82 --threads=4
+        - ./vendor/bin/infection --min-msi=50 --min-covered-msi=83 --threads=4
 
     - stage: Functional tests
       services:

--- a/src/Consumer/State.php
+++ b/src/Consumer/State.php
@@ -105,7 +105,7 @@ class State
     private function removeWatchers(): void
     {
         foreach (array_keys($this->requests) as $request) {
-            if ($this->requests[$request]['watcher'] === null) {
+            if (! isset($this->requests[$request]['watcher'])) {
                 return;
             }
 

--- a/tests/Base/Consumer/StateTest.php
+++ b/tests/Base/Consumer/StateTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace KafkaTest\Base\Consumer;
+
+use Kafka\Consumer\State;
+use PHPUnit\Framework\TestCase;
+
+final class StateTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function stopShouldNotBreakWhenNoWatchersExist(): void
+    {
+        $state = State::getInstance();
+        $state->init();
+        $state->stop();
+
+        self::assertAttributeSame([], 'callStatus', $state);
+    }
+}


### PR DESCRIPTION
If we try to stop a consumer that hasn't start properly things were not working properly due to a missing index. Now it's fixed