### PR TITLE
Make PHPCS more strict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
-        - ./vendor/bin/infection --min-msi=50 --min-covered-msi=83 --threads=4
+        - ./vendor/bin/infection --min-msi=49 --min-covered-msi=82 --threads=4
 
     - stage: Functional tests
       services:

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "ext-krb5": "To be able to ues the GSSAPI SASL mechanism"
     },
     "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "infection/infection": "^0.7",
         "kmelia/monolog-stdout-handler": "^1.2",
         "mikey179/vfsStream": "^1.6.5",
@@ -46,6 +47,7 @@
         "phpunit/phpcov": "^4.0",
         "phpunit/phpunit": "^6.5",
         "satooshi/php-coveralls": "2.0.0",
+        "slevomat/coding-standard": "^4.1",
         "squizlabs/php_codesniffer": "^3.1"
     }
 }

--- a/example/Consumer.php
+++ b/example/Consumer.php
@@ -3,13 +3,15 @@ require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
 use Monolog\Logger;
 use Monolog\Handler\StdoutHandler;
+use Kafka\ConsumerConfig;
+use Kafka\Consumer;
 
 // Create the logger
 $logger = new Logger('my_logger');
 // Now add some handlers
 $logger->pushHandler(new StdoutHandler());
 
-$config = \Kafka\ConsumerConfig::getInstance();
+$config = ConsumerConfig::getInstance();
 $config->setMetadataRefreshIntervalMs(10000);
 $config->setMetadataBrokerList('127.0.0.1:9092');
 $config->setGroupId('test');
@@ -22,7 +24,7 @@ $config->setOffsetReset('earliest');
 //$config->setSslEnable(true);
 //$config->setSslPassphrase('123456');
 //$config->setSslPeerName('nmred');
-$consumer = new \Kafka\Consumer();
+$consumer = new Consumer();
 $consumer->setLogger($logger);
 $consumer->start(function ($topic, $part, $message) {
     var_dump($message);

--- a/example/Consumer.php
+++ b/example/Consumer.php
@@ -1,10 +1,10 @@
 <?php
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
-use Monolog\Logger;
-use Monolog\Handler\StdoutHandler;
-use Kafka\ConsumerConfig;
 use Kafka\Consumer;
+use Kafka\ConsumerConfig;
+use Monolog\Handler\StdoutHandler;
+use Monolog\Logger;
 
 // Create the logger
 $logger = new Logger('my_logger');

--- a/example/Consumer.php
+++ b/example/Consumer.php
@@ -26,6 +26,6 @@ $config->setOffsetReset('earliest');
 //$config->setSslPeerName('nmred');
 $consumer = new Consumer();
 $consumer->setLogger($logger);
-$consumer->start(function ($topic, $part, $message) {
+$consumer->start(function ($topic, $part, $message): void {
     var_dump($message);
 });

--- a/example/Consumer.php
+++ b/example/Consumer.php
@@ -1,6 +1,9 @@
 <?php
+declare(strict_types=1);
+
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
+
 use Kafka\Consumer;
 use Kafka\ConsumerConfig;
 use Monolog\Handler\StdoutHandler;

--- a/example/ControlProducer.php
+++ b/example/ControlProducer.php
@@ -3,13 +3,16 @@ require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
 use Monolog\Logger;
 use Monolog\Handler\StdoutHandler;
+use Kafka\ProducerConfig;
+use Amp\Loop;
+use Kafka\Producer;
 
 // Create the logger
 $logger = new Logger('my_logger');
 // Now add some handlers
 $logger->pushHandler(new StdoutHandler());
 
-$config = \Kafka\ProducerConfig::getInstance();
+$config = ProducerConfig::getInstance();
 $config->setMetadataRefreshIntervalMs(1000);
 $config->setMetadataBrokerList('127.0.0.1:9092');
 $config->setBrokerVersion('1.0.0');
@@ -33,7 +36,7 @@ class Message
 
 // control message send interval time
 $message = new Message;
-\Amp\Loop::repeat(3000, function () use ($message) {
+Loop::repeat(3000, function () use ($message) {
     $message->setMessage([
         [
             'topic' => 'test',
@@ -43,7 +46,7 @@ $message = new Message;
     ]);
 });
 
-$producer = new \Kafka\Producer(function () use ($message) {
+$producer = new Producer(function () use ($message) {
     $tmp = $message->getMessage();
     $message->setMessage([]);
     return $tmp;

--- a/example/ControlProducer.php
+++ b/example/ControlProducer.php
@@ -1,6 +1,9 @@
 <?php
+declare(strict_types=1);
+
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
+
 use Amp\Loop;
 use Kafka\Producer;
 use Kafka\ProducerConfig;

--- a/example/ControlProducer.php
+++ b/example/ControlProducer.php
@@ -22,13 +22,23 @@ $config->setProduceInterval(500);
 
 class Message
 {
+    /**
+     * @var string[]
+     */
     private $message;
 
-    public function getMessage()
+    /**
+     * @return string[]
+     */
+    public function getMessage(): array
     {
         return $this->message;
     }
-    public function setMessage($message)
+
+    /**
+     * @param string[] $message
+     */
+    public function setMessage(array $message): void
     {
         $this->message = $message;
     }
@@ -36,7 +46,7 @@ class Message
 
 // control message send interval time
 $message = new Message;
-Loop::repeat(3000, function () use ($message) {
+Loop::repeat(3000, function () use ($message): void {
     $message->setMessage([
         [
             'topic' => 'test',
@@ -52,10 +62,10 @@ $producer = new Producer(function () use ($message) {
     return $tmp;
 });
 $producer->setLogger($logger);
-$producer->success(function ($result) {
+$producer->success(function ($result): void {
     var_dump($result);
 });
-$producer->error(function ($errorCode, $context) {
+$producer->error(function ($errorCode, $context): void {
     var_dump($errorCode);
 });
 $producer->send();

--- a/example/ControlProducer.php
+++ b/example/ControlProducer.php
@@ -1,11 +1,11 @@
 <?php
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
-use Monolog\Logger;
-use Monolog\Handler\StdoutHandler;
-use Kafka\ProducerConfig;
 use Amp\Loop;
 use Kafka\Producer;
+use Kafka\ProducerConfig;
+use Monolog\Handler\StdoutHandler;
+use Monolog\Logger;
 
 // Create the logger
 $logger = new Logger('my_logger');

--- a/example/Producer.php
+++ b/example/Producer.php
@@ -1,11 +1,11 @@
 <?php
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
-use Monolog\Logger;
-use Monolog\Handler\StdoutHandler;
-use Kafka\ProducerConfig;
 use Kafka\Config;
 use Kafka\Producer;
+use Kafka\ProducerConfig;
+use Monolog\Handler\StdoutHandler;
+use Monolog\Logger;
 
 // Create the logger
 $logger = new Logger('my_logger');

--- a/example/Producer.php
+++ b/example/Producer.php
@@ -3,20 +3,23 @@ require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
 use Monolog\Logger;
 use Monolog\Handler\StdoutHandler;
+use Kafka\ProducerConfig;
+use Kafka\Config;
+use Kafka\Producer;
 
 // Create the logger
 $logger = new Logger('my_logger');
 // Now add some handlers
 $logger->pushHandler(new StdoutHandler());
 
-$config = \Kafka\ProducerConfig::getInstance();
+$config = ProducerConfig::getInstance();
 $config->setMetadataRefreshIntervalMs(10000);
 $config->setMetadataBrokerList('127.0.0.1:9093');
 $config->setBrokerVersion('1.0.0');
 $config->setRequiredAck(1);
 $config->setIsAsyn(false);
 $config->setProduceInterval(500);
-$config->setSecurityProtocol(\Kafka\Config::SECURITY_PROTOCOL_SASL_SSL);
+$config->setSecurityProtocol(Config::SECURITY_PROTOCOL_SASL_SSL);
 $config->setSaslMechanism(\Kafka\Config::SASL_MECHANISMS_SCRAM_SHA_256);
 $config->setSaslUsername('nmred');
 $config->setSaslPassword('123456');
@@ -31,7 +34,7 @@ $config->setSslLocalPk('/home/vagrant/code/kafka-php/ca-key');
 $config->setSslPassphrase('123456');
 $config->setSslPeerName('nmred');
 
-$producer = new \Kafka\Producer(function () {
+$producer = new Producer(function () {
     return [
         [
             'topic' => 'test',

--- a/example/Producer.php
+++ b/example/Producer.php
@@ -1,6 +1,9 @@
 <?php
+declare(strict_types=1);
+
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
+
 use Kafka\Config;
 use Kafka\Producer;
 use Kafka\ProducerConfig;

--- a/example/Producer.php
+++ b/example/Producer.php
@@ -44,10 +44,10 @@ $producer = new Producer(function () {
     ];
 });
 $producer->setLogger($logger);
-$producer->success(function ($result) {
+$producer->success(function ($result): void {
     var_dump($result);
 });
-$producer->error(function ($errorCode) {
+$producer->error(function ($errorCode): void {
     var_dump($errorCode);
 });
 $producer->send(true);

--- a/example/ProducerSync.php
+++ b/example/ProducerSync.php
@@ -3,13 +3,15 @@ require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
 use Monolog\Logger;
 use Monolog\Handler\StdoutHandler;
+use Kafka\ProducerConfig;
+use Kafka\Producer;
 
 // Create the logger
 $logger = new Logger('my_logger');
 // Now add some handlers
 $logger->pushHandler(new StdoutHandler());
 
-$config = \Kafka\ProducerConfig::getInstance();
+$config = ProducerConfig::getInstance();
 $config->setMetadataRefreshIntervalMs(10000);
 $config->setMetadataBrokerList('127.0.0.1:9093');
 $config->setBrokerVersion('0.10.2.1');
@@ -24,7 +26,7 @@ $config->setProduceInterval(500);
 //$config->setSslPassphrase('123456');
 //$config->setSslPeerName('nmred');
 
-$producer = new \Kafka\Producer();
+$producer = new Producer();
 $producer->setLogger($logger);
 
 for ($i = 0; $i < 100; $i++) {

--- a/example/ProducerSync.php
+++ b/example/ProducerSync.php
@@ -1,6 +1,9 @@
 <?php
+declare(strict_types=1);
+
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
+
 use Kafka\Producer;
 use Kafka\ProducerConfig;
 use Monolog\Handler\StdoutHandler;

--- a/example/ProducerSync.php
+++ b/example/ProducerSync.php
@@ -1,10 +1,10 @@
 <?php
 require '../vendor/autoload.php';
 date_default_timezone_set('PRC');
-use Monolog\Logger;
-use Monolog\Handler\StdoutHandler;
-use Kafka\ProducerConfig;
 use Kafka\Producer;
+use Kafka\ProducerConfig;
+use Monolog\Handler\StdoutHandler;
+use Monolog\Logger;
 
 // Create the logger
 $logger = new Logger('my_logger');

--- a/example/SaslSocket.php
+++ b/example/SaslSocket.php
@@ -1,7 +1,7 @@
 <?php
 require '../vendor/autoload.php';
 
-use \Kafka\Sasl\Scram;
+use Kafka\Sasl\Scram;
 
 \Kafka\Protocol::init('1.0.0');
 //$provider = new \Kafka\Sasl\Plain('nmred', '123456');

--- a/example/SaslSocket.php
+++ b/example/SaslSocket.php
@@ -1,8 +1,8 @@
 <?php
 require '../vendor/autoload.php';
 
-use Kafka\Sasl\Scram;
 use Kafka\Protocol;
+use Kafka\Sasl\Scram;
 use Kafka\SocketSync;
 
 Protocol::init('1.0.0');

--- a/example/SaslSocket.php
+++ b/example/SaslSocket.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 require '../vendor/autoload.php';
 
 use Kafka\Protocol;

--- a/example/SaslSocket.php
+++ b/example/SaslSocket.php
@@ -2,13 +2,15 @@
 require '../vendor/autoload.php';
 
 use Kafka\Sasl\Scram;
+use Kafka\Protocol;
+use Kafka\SocketSync;
 
-\Kafka\Protocol::init('1.0.0');
+Protocol::init('1.0.0');
 //$provider = new \Kafka\Sasl\Plain('nmred', '123456');
 //$provider = new \Kafka\Sasl\Gssapi('/etc/security/keytabs/kafkaclient.keytab', 'kafka/node1@NMREDKAFKA.COM');
 $provider = new Scram('alice', 'alice-secret', Scram::SCRAM_SHA_256);
 
-$socket = new \Kafka\SocketSync('127.0.0.1', '9092', null, $provider);
+$socket = new SocketSync('127.0.0.1', '9092', null, $provider);
 $socket->connect();
 
 $data = [

--- a/example/protocol/ApiVerions.php
+++ b/example/protocol/ApiVerions.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/ApiVerions.php
+++ b/example/protocol/ApiVerions.php
@@ -1,10 +1,12 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
-\Kafka\Protocol::init('1.0.0');
+Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::API_VERSIONS_REQUEST, []);
 
-$socket = new \Kafka\Socket('127.0.0.1', '9092');
+$socket = new Socket('127.0.0.1', '9092');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::API_VERSIONS_REQUEST, substr($data, 4));

--- a/example/protocol/ApiVerions.php
+++ b/example/protocol/ApiVerions.php
@@ -7,7 +7,7 @@ Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::API_VERSIONS_REQUEST, []);
 
 $socket = new Socket('127.0.0.1', '9092');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::API_VERSIONS_REQUEST, substr($data, 4));
     echo json_encode($result);
@@ -16,5 +16,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\Loop::run(function () use ($socket, $requestData) {
+Amp\Loop::run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/CommitOffset.php
+++ b/example/protocol/CommitOffset.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/CommitOffset.php
+++ b/example/protocol/CommitOffset.php
@@ -66,9 +66,7 @@ class CommitOffset
                     'assignments' => [
                         [
                             'topic_name' => 'test',
-                            'partitions' => [
-                                0,
-                            ],
+                            'partitions' => [0],
                         ],
                     ],
                 ],

--- a/example/protocol/CommitOffset.php
+++ b/example/protocol/CommitOffset.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 class CommitOffset
 {
@@ -24,10 +26,10 @@ class CommitOffset
             ],
         ];
 
-        \Kafka\Protocol::init('0.9.1.0');
+        Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
-        $socket = new \Kafka\Socket('127.0.0.1', '9192');
+        $socket = new Socket('127.0.0.1', '9192');
         $socket->setOnReadable(function ($data) {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));

--- a/example/protocol/CommitOffset.php
+++ b/example/protocol/CommitOffset.php
@@ -59,7 +59,7 @@ class CommitOffset
                         [
                             'topic_name' => 'test',
                             'partitions' => [
-                                0
+                                0,
                             ],
                         ],
                     ],
@@ -104,9 +104,9 @@ class CommitOffset
                             'partition' => 0,
                             'offset' => 45,
                             'metadata' => '',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
         ];
 

--- a/example/protocol/CommitOffset.php
+++ b/example/protocol/CommitOffset.php
@@ -5,11 +5,14 @@ use Kafka\Socket;
 
 class CommitOffset
 {
+    /**
+     * @var string[]
+     */
     protected $group = [];
     // {{{ functions
     // {{{ protected function joinGroup()
 
-    protected function joinGroup()
+    protected function joinGroup(): void
     {
         $data = [
             'group_id' => 'test',
@@ -30,7 +33,7 @@ class CommitOffset
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
         $socket = new Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
             $this->group = $result;
@@ -39,14 +42,14 @@ class CommitOffset
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ protected function syncGroup()
 
-    protected function syncGroup()
+    protected function syncGroup(): void
     {
         $this->joinGroup();
         $data = [
@@ -73,7 +76,7 @@ class CommitOffset
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SYNC_GROUP_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
             //echo json_encode($result);
@@ -82,14 +85,14 @@ class CommitOffset
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ public function run()
 
-    public function run()
+    public function run(): void
     {
         $this->joinGroup();
         $this->syncGroup();
@@ -116,7 +119,7 @@ class CommitOffset
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_COMMIT_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_COMMIT_REQUEST, substr($data, 4));
             echo json_encode($result);
@@ -125,7 +128,7 @@ class CommitOffset
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 

--- a/example/protocol/DescribeGroups.php
+++ b/example/protocol/DescribeGroups.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/DescribeGroups.php
+++ b/example/protocol/DescribeGroups.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 class DescribeGroups
 {
@@ -24,10 +26,10 @@ class DescribeGroups
             ],
         ];
 
-        \Kafka\Protocol::init('0.9.1.0');
+        Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
-        $socket = new \Kafka\Socket('127.0.0.1', '9192');
+        $socket = new Socket('127.0.0.1', '9192');
         $socket->setOnReadable(function ($data) {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));

--- a/example/protocol/DescribeGroups.php
+++ b/example/protocol/DescribeGroups.php
@@ -59,7 +59,7 @@ class DescribeGroups
                         [
                             'topic_name' => 'test',
                             'partitions' => [
-                                0
+                                0,
                             ],
                         ],
                     ],
@@ -92,7 +92,7 @@ class DescribeGroups
         $this->joinGroup();
         $this->syncGroup();
         $data = [
-            'test'
+            'test',
         ];
 
         \Kafka\Protocol::init('0.9.1.0');

--- a/example/protocol/DescribeGroups.php
+++ b/example/protocol/DescribeGroups.php
@@ -5,11 +5,14 @@ use Kafka\Socket;
 
 class DescribeGroups
 {
+    /**
+     * @var string[]
+     */
     protected $group = [];
     // {{{ functions
     // {{{ protected function joinGroup()
 
-    protected function joinGroup()
+    protected function joinGroup(): void
     {
         $data = [
             'group_id' => 'test',
@@ -30,7 +33,7 @@ class DescribeGroups
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
         $socket = new Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
             $this->group = $result;
@@ -39,14 +42,14 @@ class DescribeGroups
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ protected function syncGroup()
 
-    protected function syncGroup()
+    protected function syncGroup(): void
     {
         $this->joinGroup();
         $data = [
@@ -73,7 +76,7 @@ class DescribeGroups
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SYNC_GROUP_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
             //echo json_encode($result);
@@ -82,14 +85,14 @@ class DescribeGroups
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ public function run()
 
-    public function run()
+    public function run(): void
     {
         $this->joinGroup();
         $this->syncGroup();
@@ -101,7 +104,7 @@ class DescribeGroups
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::DESCRIBE_GROUPS_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::DESCRIBE_GROUPS_REQUEST, substr($data, 4));
             echo json_encode($result);
@@ -110,7 +113,7 @@ class DescribeGroups
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 

--- a/example/protocol/DescribeGroups.php
+++ b/example/protocol/DescribeGroups.php
@@ -66,9 +66,7 @@ class DescribeGroups
                     'assignments' => [
                         [
                             'topic_name' => 'test',
-                            'partitions' => [
-                                0,
-                            ],
+                            'partitions' => [0],
                         ],
                     ],
                 ],
@@ -99,9 +97,7 @@ class DescribeGroups
     {
         $this->joinGroup();
         $this->syncGroup();
-        $data = [
-            'test',
-        ];
+        $data = ['test'];
 
         \Kafka\Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::DESCRIBE_GROUPS_REQUEST, $data);

--- a/example/protocol/Fetch.php
+++ b/example/protocol/Fetch.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/Fetch.php
+++ b/example/protocol/Fetch.php
@@ -13,7 +13,7 @@ $data = [
                     'partition_id' => 0,
                     'offset' => 45,
                     'max_bytes' => 1024,
-                ]
+                ],
             ],
         ],
     ],

--- a/example/protocol/Fetch.php
+++ b/example/protocol/Fetch.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = [
     'max_wait_time' => 1000,
@@ -19,10 +21,10 @@ $data = [
     ],
 ];
 
-\Kafka\Protocol::init('0.9.1.0');
+Protocol::init('0.9.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::FETCH_REQUEST, $data);
 
-$socket = new \Kafka\Socket('127.0.0.1', '9192');
+$socket = new Socket('127.0.0.1', '9192');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::FETCH_REQUEST, substr($data, 4));

--- a/example/protocol/Fetch.php
+++ b/example/protocol/Fetch.php
@@ -25,7 +25,7 @@ Protocol::init('0.9.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::FETCH_REQUEST, $data);
 
 $socket = new Socket('127.0.0.1', '9192');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::FETCH_REQUEST, substr($data, 4));
     echo json_encode($result);
@@ -34,5 +34,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\run(function () use ($socket, $requestData) {
+Amp\run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/FetchOffset.php
+++ b/example/protocol/FetchOffset.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/FetchOffset.php
+++ b/example/protocol/FetchOffset.php
@@ -6,8 +6,8 @@ $data = [
     'data' => [
         [
             'topic_name' => 'test',
-            'partitions' => [0]
-        ]
+            'partitions' => [0],
+        ],
     ],
 ];
 

--- a/example/protocol/FetchOffset.php
+++ b/example/protocol/FetchOffset.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = [
     'group_id' => 'test',
@@ -11,15 +13,15 @@ $data = [
     ],
 ];
 
-\Kafka\Protocol::init('0.9.1.0');
+Protocol::init('0.9.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_FETCH_REQUEST, $data);
-var_dump(\bin2hex($requestData));
+var_dump(bin2hex($requestData));
 
-$socket = new \Kafka\Socket('127.0.0.1', '9192');
+$socket = new Socket('127.0.0.1', '9192');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_FETCH_REQUEST, substr($data, 4));
-    echo \bin2hex(substr($data, 4));
+    echo bin2hex(substr($data, 4));
     echo json_encode($result);
     Amp\stop();
 });

--- a/example/protocol/FetchOffset.php
+++ b/example/protocol/FetchOffset.php
@@ -18,7 +18,7 @@ $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_FETCH_REQUEST, $d
 var_dump(bin2hex($requestData));
 
 $socket = new Socket('127.0.0.1', '9192');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_FETCH_REQUEST, substr($data, 4));
     echo bin2hex(substr($data, 4));
@@ -28,5 +28,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\run(function () use ($socket, $requestData) {
+Amp\run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/Group.php
+++ b/example/protocol/Group.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/Group.php
+++ b/example/protocol/Group.php
@@ -6,9 +6,7 @@ require '../../vendor/autoload.php';
 use Kafka\Protocol;
 use Kafka\Socket;
 
-$data = [
-    'group_id' => 'test',
-];
+$data = ['group_id' => 'test'];
 
 Protocol::init('0.9.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, $data);

--- a/example/protocol/Group.php
+++ b/example/protocol/Group.php
@@ -11,7 +11,7 @@ Protocol::init('0.9.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, $data);
 
 $socket = new Socket('127.0.0.1', '9092');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, substr($data, 4));
     echo json_encode($result);
@@ -20,5 +20,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\Loop::run(function () use ($socket, $requestData) {
+Amp\Loop::run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/Group.php
+++ b/example/protocol/Group.php
@@ -1,14 +1,16 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = [
     'group_id' => 'test',
 ];
 
-\Kafka\Protocol::init('0.9.1.0');
+Protocol::init('0.9.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, $data);
 
-$socket = new \Kafka\Socket('127.0.0.1', '9092');
+$socket = new Socket('127.0.0.1', '9092');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, substr($data, 4));

--- a/example/protocol/Heartbeat.php
+++ b/example/protocol/Heartbeat.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/Heartbeat.php
+++ b/example/protocol/Heartbeat.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 class Heartbeat
 {
@@ -24,10 +26,10 @@ class Heartbeat
             ],
         ];
 
-        \Kafka\Protocol::init('0.9.1.0');
+        Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
-        $socket = new \Kafka\Socket('127.0.0.1', '9192');
+        $socket = new Socket('127.0.0.1', '9192');
         $socket->setOnReadable(function ($data) {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));

--- a/example/protocol/Heartbeat.php
+++ b/example/protocol/Heartbeat.php
@@ -59,7 +59,7 @@ class Heartbeat
                         [
                             'topic_name' => 'test',
                             'partitions' => [
-                                0
+                                0,
                             ],
                         ],
                     ],

--- a/example/protocol/Heartbeat.php
+++ b/example/protocol/Heartbeat.php
@@ -5,11 +5,14 @@ use Kafka\Socket;
 
 class Heartbeat
 {
+    /**
+     * @var string[]
+     */
     protected $group = [];
     // {{{ functions
     // {{{ protected function joinGroup()
 
-    protected function joinGroup()
+    protected function joinGroup(): void
     {
         $data = [
             'group_id' => 'test',
@@ -30,7 +33,7 @@ class Heartbeat
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
         $socket = new Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
             $this->group = $result;
@@ -39,14 +42,14 @@ class Heartbeat
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ protected function syncGroup()
 
-    protected function syncGroup()
+    protected function syncGroup(): void
     {
         $this->joinGroup();
         $data = [
@@ -73,7 +76,7 @@ class Heartbeat
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SYNC_GROUP_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
             //echo json_encode($result);
@@ -82,14 +85,14 @@ class Heartbeat
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ public function run()
 
-    public function run()
+    public function run(): void
     {
         $this->joinGroup();
         $this->syncGroup();
@@ -103,7 +106,7 @@ class Heartbeat
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::HEART_BEAT_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::HEART_BEAT_REQUEST, substr($data, 4));
             echo json_encode($result);
@@ -112,7 +115,7 @@ class Heartbeat
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 

--- a/example/protocol/Heartbeat.php
+++ b/example/protocol/Heartbeat.php
@@ -66,9 +66,7 @@ class Heartbeat
                     'assignments' => [
                         [
                             'topic_name' => 'test',
-                            'partitions' => [
-                                0,
-                            ],
+                            'partitions' => [0],
                         ],
                     ],
                 ],

--- a/example/protocol/JoinGroup.php
+++ b/example/protocol/JoinGroup.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/JoinGroup.php
+++ b/example/protocol/JoinGroup.php
@@ -24,7 +24,7 @@ $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $dat
 var_dump(bin2hex($requestData));
 
 $socket = new Socket('127.0.0.1', '9192');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
     echo bin2hex(substr($data, 4));
@@ -34,5 +34,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\run(function () use ($socket, $requestData) {
+Amp\run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/JoinGroup.php
+++ b/example/protocol/JoinGroup.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = [
     'group_id' => 'test',
@@ -17,15 +19,15 @@ $data = [
     ],
 ];
 
-\Kafka\Protocol::init('0.9.1.0');
+Protocol::init('0.9.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
-var_dump(\bin2hex($requestData));
+var_dump(bin2hex($requestData));
 
-$socket = new \Kafka\Socket('127.0.0.1', '9192');
+$socket = new Socket('127.0.0.1', '9192');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
-    echo \bin2hex(substr($data, 4));
+    echo bin2hex(substr($data, 4));
     echo json_encode($result);
     Amp\stop();
 });

--- a/example/protocol/LeaveGroup.php
+++ b/example/protocol/LeaveGroup.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/LeaveGroup.php
+++ b/example/protocol/LeaveGroup.php
@@ -66,9 +66,7 @@ class LeaveGroup
                     'assignments' => [
                         [
                             'topic_name' => 'test',
-                            'partitions' => [
-                                0,
-                            ],
+                            'partitions' => [0],
                         ],
                     ],
                 ],

--- a/example/protocol/LeaveGroup.php
+++ b/example/protocol/LeaveGroup.php
@@ -5,11 +5,14 @@ use Kafka\Socket;
 
 class LeaveGroup
 {
+    /**
+     * @var string[]
+     */
     protected $group = [];
     // {{{ functions
     // {{{ protected function joinGroup()
 
-    protected function joinGroup()
+    protected function joinGroup(): void
     {
         $data = [
             'group_id' => 'test',
@@ -30,7 +33,7 @@ class LeaveGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
         $socket = new Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
             $this->group = $result;
@@ -39,14 +42,14 @@ class LeaveGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ protected function syncGroup()
 
-    protected function syncGroup()
+    protected function syncGroup(): void
     {
         $this->joinGroup();
         $data = [
@@ -73,7 +76,7 @@ class LeaveGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SYNC_GROUP_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
             //echo json_encode($result);
@@ -82,14 +85,14 @@ class LeaveGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ public function run()
 
-    public function run()
+    public function run(): void
     {
         $this->joinGroup();
         $this->syncGroup();
@@ -102,7 +105,7 @@ class LeaveGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::LEAVE_GROUP_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::LEAVE_GROUP_REQUEST, substr($data, 4));
             echo json_encode($result);
@@ -111,7 +114,7 @@ class LeaveGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 

--- a/example/protocol/LeaveGroup.php
+++ b/example/protocol/LeaveGroup.php
@@ -59,7 +59,7 @@ class LeaveGroup
                         [
                             'topic_name' => 'test',
                             'partitions' => [
-                                0
+                                0,
                             ],
                         ],
                     ],

--- a/example/protocol/LeaveGroup.php
+++ b/example/protocol/LeaveGroup.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 class LeaveGroup
 {
@@ -24,10 +26,10 @@ class LeaveGroup
             ],
         ];
 
-        \Kafka\Protocol::init('0.9.1.0');
+        Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
-        $socket = new \Kafka\Socket('127.0.0.1', '9192');
+        $socket = new Socket('127.0.0.1', '9192');
         $socket->setOnReadable(function ($data) {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));

--- a/example/protocol/ListGroup.php
+++ b/example/protocol/ListGroup.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/ListGroup.php
+++ b/example/protocol/ListGroup.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 class ListGroup
 {
@@ -24,10 +26,10 @@ class ListGroup
             ],
         ];
 
-        \Kafka\Protocol::init('0.9.1.0');
+        Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
-        $socket = new \Kafka\Socket('127.0.0.1', '9192');
+        $socket = new Socket('127.0.0.1', '9192');
         $socket->setOnReadable(function ($data) {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));

--- a/example/protocol/ListGroup.php
+++ b/example/protocol/ListGroup.php
@@ -5,11 +5,14 @@ use Kafka\Socket;
 
 class ListGroup
 {
+    /**
+     * @var string[]
+     */
     protected $group = [];
     // {{{ functions
     // {{{ protected function joinGroup()
 
-    protected function joinGroup()
+    protected function joinGroup(): void
     {
         $data = [
             'group_id' => 'test',
@@ -30,7 +33,7 @@ class ListGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
         $socket = new Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
             $this->group = $result;
@@ -39,14 +42,14 @@ class ListGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ protected function syncGroup()
 
-    protected function syncGroup()
+    protected function syncGroup(): void
     {
         $this->joinGroup();
         $data = [
@@ -73,7 +76,7 @@ class ListGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SYNC_GROUP_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
             //echo json_encode($result);
@@ -82,14 +85,14 @@ class ListGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ public function run()
 
-    public function run()
+    public function run(): void
     {
         $this->joinGroup();
         $this->syncGroup();
@@ -100,7 +103,7 @@ class ListGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::LIST_GROUPS_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::LIST_GROUPS_REQUEST, substr($data, 4));
             echo json_encode($result);
@@ -109,7 +112,7 @@ class ListGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 

--- a/example/protocol/ListGroup.php
+++ b/example/protocol/ListGroup.php
@@ -59,7 +59,7 @@ class ListGroup
                         [
                             'topic_name' => 'test',
                             'partitions' => [
-                                0
+                                0,
                             ],
                         ],
                     ],

--- a/example/protocol/ListGroup.php
+++ b/example/protocol/ListGroup.php
@@ -66,9 +66,7 @@ class ListGroup
                     'assignments' => [
                         [
                             'topic_name' => 'test',
-                            'partitions' => [
-                                0,
-                            ],
+                            'partitions' => [0],
                         ],
                     ],
                 ],
@@ -99,8 +97,7 @@ class ListGroup
     {
         $this->joinGroup();
         $this->syncGroup();
-        $data = [
-        ];
+        $data = [];
 
         \Kafka\Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::LIST_GROUPS_REQUEST, $data);

--- a/example/protocol/MetaData.php
+++ b/example/protocol/MetaData.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/MetaData.php
+++ b/example/protocol/MetaData.php
@@ -2,7 +2,7 @@
 require '../../vendor/autoload.php';
 
 $data = [
-    'test'
+    'test',
 ];
 
 \Kafka\Protocol::init('1.0.0');

--- a/example/protocol/MetaData.php
+++ b/example/protocol/MetaData.php
@@ -6,9 +6,7 @@ require '../../vendor/autoload.php';
 use Kafka\Protocol;
 use Kafka\Socket;
 
-$data = [
-    'test',
-];
+$data = ['test'];
 
 Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::METADATA_REQUEST, $data);

--- a/example/protocol/MetaData.php
+++ b/example/protocol/MetaData.php
@@ -1,14 +1,16 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = [
     'test',
 ];
 
-\Kafka\Protocol::init('1.0.0');
+Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::METADATA_REQUEST, $data);
 
-$socket = new \Kafka\Socket('127.0.0.1', '9093');
+$socket = new Socket('127.0.0.1', '9093');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::METADATA_REQUEST, substr($data, 4));

--- a/example/protocol/MetaData.php
+++ b/example/protocol/MetaData.php
@@ -11,7 +11,7 @@ Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::METADATA_REQUEST, $data);
 
 $socket = new Socket('127.0.0.1', '9093');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::METADATA_REQUEST, substr($data, 4));
     echo json_encode($result);
@@ -21,5 +21,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\Loop::run(function () use ($socket, $requestData) {
+Amp\Loop::run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/Offset.php
+++ b/example/protocol/Offset.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/Offset.php
+++ b/example/protocol/Offset.php
@@ -23,7 +23,7 @@ Protocol::init('0.10.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_REQUEST, $data);
 
 $socket = new Socket('127.0.0.1', '9292');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_REQUEST, substr($data, 4));
     echo json_encode($result);
@@ -32,5 +32,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\run(function () use ($socket, $requestData) {
+Amp\run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/Offset.php
+++ b/example/protocol/Offset.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = [
     'replica_id' => -1,
@@ -17,10 +19,10 @@ $data = [
     ],
 ];
 
-\Kafka\Protocol::init('0.10.1.0');
+Protocol::init('0.10.1.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_REQUEST, $data);
 
-$socket = new \Kafka\Socket('127.0.0.1', '9292');
+$socket = new Socket('127.0.0.1', '9292');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_REQUEST, substr($data, 4));

--- a/example/protocol/Produce.php
+++ b/example/protocol/Produce.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/Produce.php
+++ b/example/protocol/Produce.php
@@ -26,7 +26,7 @@ Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::PRODUCE_REQUEST, $data);
 
 $socket = new Socket('127.0.0.1', '9092');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::PRODUCE_REQUEST, substr($data, 4));
     echo json_encode($result);
@@ -35,5 +35,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\Loop::run(function () use ($socket, $requestData) {
+Amp\Loop::run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/Produce.php
+++ b/example/protocol/Produce.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = [
     'required_ack' => 1,
@@ -20,10 +22,10 @@ $data = [
     ],
 ];
 
-\Kafka\Protocol::init('1.0.0');
+Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::PRODUCE_REQUEST, $data);
 
-$socket = new \Kafka\Socket('127.0.0.1', '9092');
+$socket = new Socket('127.0.0.1', '9092');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::PRODUCE_REQUEST, substr($data, 4));

--- a/example/protocol/SaslHandShake.php
+++ b/example/protocol/SaslHandShake.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/SaslHandShake.php
+++ b/example/protocol/SaslHandShake.php
@@ -8,7 +8,7 @@ Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SASL_HAND_SHAKE_REQUEST, $data);
 
 $socket = new Socket('127.0.0.1', '9092');
-$socket->setOnReadable(function ($data) {
+$socket->setOnReadable(function ($data): void {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::SASL_HAND_SHAKE_REQUEST, substr($data, 4));
     echo json_encode($result);
@@ -18,5 +18,5 @@ $socket->setOnReadable(function ($data) {
 
 $socket->connect();
 $socket->write($requestData);
-Amp\Loop::run(function () use ($socket, $requestData) {
+Amp\Loop::run(function () use ($socket, $requestData): void {
 });

--- a/example/protocol/SaslHandShake.php
+++ b/example/protocol/SaslHandShake.php
@@ -1,11 +1,13 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 $data = 'PLAIN';
-\Kafka\Protocol::init('1.0.0');
+Protocol::init('1.0.0');
 $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SASL_HAND_SHAKE_REQUEST, $data);
 
-$socket = new \Kafka\Socket('127.0.0.1', '9092');
+$socket = new Socket('127.0.0.1', '9092');
 $socket->setOnReadable(function ($data) {
     $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
     $result = \Kafka\Protocol::decode(\Kafka\Protocol::SASL_HAND_SHAKE_REQUEST, substr($data, 4));

--- a/example/protocol/SyncGroup.php
+++ b/example/protocol/SyncGroup.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require '../../vendor/autoload.php';
+
 use Kafka\Protocol;
 use Kafka\Socket;
 

--- a/example/protocol/SyncGroup.php
+++ b/example/protocol/SyncGroup.php
@@ -59,7 +59,7 @@ class SyncGroup
                         [
                             'topic_name' => 'test',
                             'partitions' => [
-                                0
+                                0,
                             ],
                         ],
                     ],

--- a/example/protocol/SyncGroup.php
+++ b/example/protocol/SyncGroup.php
@@ -5,11 +5,14 @@ use Kafka\Socket;
 
 class SyncGroup
 {
+    /**
+     * @var string[]
+     */
     protected $group = [];
     // {{{ functions
     // {{{ protected function joinGroup()
 
-    protected function joinGroup()
+    protected function joinGroup(): void
     {
         $data = [
             'group_id' => 'test',
@@ -30,7 +33,7 @@ class SyncGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
         $socket = new Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
             $this->group = $result;
@@ -39,14 +42,14 @@ class SyncGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 
     // }}}
     // {{{ public function run()
 
-    public function run()
+    public function run(): void
     {
         $this->joinGroup();
         $data = [
@@ -73,7 +76,7 @@ class SyncGroup
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::SYNC_GROUP_REQUEST, $data);
 
         $socket = new \Kafka\Socket('127.0.0.1', '9192');
-        $socket->setOnReadable(function ($data) {
+        $socket->setOnReadable(function ($data): void {
             $coodid = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
             echo json_encode($result);
@@ -82,7 +85,7 @@ class SyncGroup
 
         $socket->connect();
         $socket->write($requestData);
-        Amp\run(function () use ($socket, $requestData) {
+        Amp\run(function () use ($socket, $requestData): void {
         });
     }
 

--- a/example/protocol/SyncGroup.php
+++ b/example/protocol/SyncGroup.php
@@ -1,5 +1,7 @@
 <?php
 require '../../vendor/autoload.php';
+use Kafka\Protocol;
+use Kafka\Socket;
 
 class SyncGroup
 {
@@ -24,10 +26,10 @@ class SyncGroup
             ],
         ];
 
-        \Kafka\Protocol::init('0.9.1.0');
+        Protocol::init('0.9.1.0');
         $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $data);
 
-        $socket = new \Kafka\Socket('127.0.0.1', '9192');
+        $socket = new Socket('127.0.0.1', '9192');
         $socket->setOnReadable(function ($data) {
             $coodid      = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
             $result      = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));

--- a/example/protocol/SyncGroup.php
+++ b/example/protocol/SyncGroup.php
@@ -66,9 +66,7 @@ class SyncGroup
                     'assignments' => [
                         [
                             'topic_name' => 'test',
-                            'partitions' => [
-                                0,
-                            ],
+                            'partitions' => [0],
                         ],
                     ],
                 ],

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -52,5 +52,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing" />
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse" />
+    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -64,5 +64,12 @@
             <property name="allowFullyQualifiedNameForCollidingClasses" type="boolean" value="true"/>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces">
+        <properties>
+            <property name="linesCountAfterOpeningBrace" value="0"/>
+            <property name="linesCountBeforeClosingBrace" value="0"/>
+        </properties>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -46,5 +46,6 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace" />
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -47,5 +47,6 @@
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" />
+    <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -174,5 +174,12 @@
     <rule ref="Generic.PHP.DisallowShortOpenTag"/>
     <rule ref="Generic.PHP.SAPIUsage"/>
     <rule ref="PEAR.Commenting.InlineComment"/>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants">
+        <exclude-pattern>*/example/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions">
+        <exclude-pattern>*/example/*</exclude-pattern>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -116,5 +116,10 @@
             <property name="spacesCountAroundEqualsSign" value="0" />
         </properties>
     </rule>
+
+    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+        <message>Variable "%s" not allowed in double quoted string; use sprintf() or concatenation instead</message>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -153,5 +153,9 @@
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
         <severity>5</severity>
     </rule>
+
+    <rule ref="Generic.CodeAnalysis.EmptyStatement">
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH"/>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -72,5 +72,35 @@
             <property name="linesCountBeforeClosingBrace" value="0"/>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+        <properties>
+            <property name="enableEachParameterAndReturnInspection" value="true"/>
+            <property name="traversableTypeHints" type="array" value="Doctrine\Common\Collections\Collection"/>
+            <property
+                    name="usefulAnnotations"
+                    type="array"
+                    value="
+                    @before,
+                    @beforeClass,
+                    @after,
+                    @afterClass,
+                    @test,
+                    @dataProvider,
+                    @deprecated,
+                    @expectedException,
+                    @expectedExceptionMessage,
+                    @expectedExceptionMessageRegExp,
+                    @expectedExceptionCode,
+                    @expectedDeprecation,
+                    @group,
+                    @internal,
+                    @link,
+                    @see,
+                    @throws
+                "
+            />
+        </properties>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -157,5 +157,7 @@
     <rule ref="Generic.CodeAnalysis.EmptyStatement">
         <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCATCH"/>
     </rule>
+
+    <rule ref="Squiz.PHP.NonExecutableCode"/>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -121,5 +121,14 @@
     <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
         <message>Variable "%s" not allowed in double quoted string; use sprintf() or concatenation instead</message>
     </rule>
+
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+
+    <rule ref="Squiz.Arrays.ArrayDeclaration">
+        <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -39,5 +39,6 @@
 
     <!-- strict rules -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators" />
+    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -49,5 +49,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" />
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -50,5 +50,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -42,5 +42,6 @@
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition" />
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses" />
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -56,6 +56,7 @@
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" />
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
 
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,5 +51,6 @@
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing" />
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -109,5 +109,12 @@
             <property name="searchAnnotations" type="boolean" value="true"/>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="1" />
+            <property name="spacesCountAroundEqualsSign" value="0" />
+        </properties>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,5 +40,6 @@
     <!-- strict rules -->
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators" />
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -159,5 +159,20 @@
     </rule>
 
     <rule ref="Squiz.PHP.NonExecutableCode"/>
+
+    <rule ref="Squiz.Scope.StaticThisUsage"/>
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+    <rule ref="Squiz.Functions.GlobalFunction"/>
+    <rule ref="Squiz.PHP.GlobalKeyword"/>
+    <rule ref="Squiz.PHP.InnerFunctions"/>
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+    <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
+    <rule ref="Generic.PHP.BacktickOperator"/>
+    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+    <rule ref="Generic.PHP.SAPIUsage"/>
+    <rule ref="PEAR.Commenting.InlineComment"/>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -103,5 +103,11 @@
             />
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" type="boolean" value="true"/>
+        </properties>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -55,6 +55,7 @@
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" />
 
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,5 +41,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators" />
     <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition" />
+    <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -54,5 +54,6 @@
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse" />
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
+    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,5 +53,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing" />
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse" />
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,5 +36,8 @@
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
         <exclude-pattern>*/tests\/Base\/StreamStub/*</exclude-pattern>
     </rule>
+
+    <!-- strict rules -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,5 +43,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition" />
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses" />
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,5 +45,6 @@
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements" />
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace" />
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
+    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,5 +48,6 @@
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma" />
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" />
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -55,5 +55,14 @@
     <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine" />
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
+
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFullyQualifiedGlobalClasses" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalFunctions" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalConstants" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingClasses" type="boolean" value="true"/>
+        </properties>
+    </rule>
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,5 +44,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses" />
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements" />
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace" />
+    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch" />
 </ruleset>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -130,5 +130,28 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
     </rule>
+
+    <rule ref="Squiz.Strings.EchoedStrings"/>
+    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
+    <rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
+    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
+    <rule ref="Generic.Files.EndFileNewline"/>
+    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
+
+    <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+        <severity>5</severity>
+    </rule>
 </ruleset>
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,4 +4,5 @@ includes:
 
 parameters:
     ignoreErrors:
-        - '#Call to an undefined method Kafka\\ConsumerConfig::(g|s)etValidKey\(\)#'
+        - '#Call to an undefined method Kafka\\Config.*::(g|s)etValidKey\(\)#'
+        - '#Call to an undefined method Kafka\\Config.*::pureMagic\(\)#'

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -213,7 +213,7 @@ class Broker
     /**
      * @throws \Kafka\Exception
      */
-    private function judgeConnectionConfig() : ?SaslMechanism
+    private function judgeConnectionConfig(): ?SaslMechanism
     {
         if ($this->config === null) {
             return null;
@@ -243,7 +243,7 @@ class Broker
     /**
      * @throws \Kafka\Exception
      */
-    private function getSaslMechanismProvider(Config $config) : SaslMechanism
+    private function getSaslMechanismProvider(Config $config): SaslMechanism
     {
         $mechanism = $config->getSaslMechanism();
         $username  = $config->getSaslUsername();

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Kafka\Sasl\Gssapi;
@@ -139,7 +141,7 @@ class Broker
             return null;
         }
 
-        return $this->getMetaConnect($nodeIds[0], $modeSync);
+        return $this->getMetaConnect((string) $nodeIds[0], $modeSync);
     }
 
     public function getDataConnect(string $key, bool $modeSync = false): ?CommonSocket
@@ -178,7 +180,7 @@ class Broker
         }
 
         try {
-            $socket = $this->getSocket($host, $port, $modeSync);
+            $socket = $this->getSocket((string) $host, (int) $port, $modeSync);
 
             if ($socket instanceof Socket && $this->process !== null) {
                 $socket->setOnReadable($this->process);

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -178,7 +178,7 @@ class Broker
             $this->{$type}[$key] = $socket;
 
             return $socket;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->error($e->getMessage());
             return false;
         }

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -221,12 +221,12 @@ class Broker
 
         $plainConnections = [
             Config::SECURITY_PROTOCOL_PLAINTEXT,
-            Config::SECURITY_PROTOCOL_SASL_PLAINTEXT
+            Config::SECURITY_PROTOCOL_SASL_PLAINTEXT,
         ];
 
         $saslConnections = [
             Config::SECURITY_PROTOCOL_SASL_SSL,
-            Config::SECURITY_PROTOCOL_SASL_PLAINTEXT
+            Config::SECURITY_PROTOCOL_SASL_PLAINTEXT,
         ];
 
         $securityProtocol = $this->config->getSecurityProtocol();

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -80,7 +80,7 @@ class Broker
 
         $changed = false;
 
-        if (serialize($this->brokers) !== serialize($brokers)) {
+        if (\serialize($this->brokers) !== \serialize($brokers)) {
             $this->brokers = $brokers;
 
             $changed = true;
@@ -102,7 +102,7 @@ class Broker
             $newTopics[$topic['topicName']] = $item;
         }
 
-        if (serialize($this->topics) !== serialize($newTopics)) {
+        if (\serialize($this->topics) !== \serialize($newTopics)) {
             $this->topics = $newTopics;
 
             $changed = true;
@@ -134,8 +134,8 @@ class Broker
 
     public function getRandConnect(bool $modeSync = false): ?CommonSocket
     {
-        $nodeIds = array_keys($this->brokers);
-        shuffle($nodeIds);
+        $nodeIds = \array_keys($this->brokers);
+        \shuffle($nodeIds);
 
         if (! isset($nodeIds[0])) {
             return null;
@@ -168,11 +168,11 @@ class Broker
         if (isset($this->brokers[$key])) {
             $hostname = $this->brokers[$key];
 
-            [$host, $port] = explode(':', $hostname);
+            [$host, $port] = \explode(':', $hostname);
         }
 
-        if (strpos($key, ':') !== false) {
-            [$host, $port] = explode(':', $key);
+        if (\strpos($key, ':') !== false) {
+            [$host, $port] = \explode(':', $key);
         }
 
         if ($host === null || $port === null || (! $modeSync && $this->process === null)) {
@@ -272,6 +272,6 @@ class Broker
                 return new Scram($username, $password, Scram::SCRAM_SHA_512);
         }
 
-        throw new Exception(sprintf('"%s" is an invalid SASL mechanism', $mechanism));
+        throw new Exception(\sprintf('"%s" is an invalid SASL mechanism', $mechanism));
     }
 }

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -84,7 +84,7 @@ class Broker
 
         $newTopics = [];
         foreach ($topics as $topic) {
-            if ((int) $topic['errorCode'] !== \Kafka\Protocol::NO_ERROR) {
+            if ((int) $topic['errorCode'] !== Protocol::NO_ERROR) {
                 $this->error('Parse metadata for topic is error, error:' . \Kafka\Protocol::getError($topic['errorCode']));
                 continue;
             }

--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 abstract class CommonSocket

--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -79,27 +79,27 @@ abstract class CommonSocket
         $this->saslProvider = $saslProvider;
     }
 
-    public function setSendTimeoutSec(float $sendTimeoutSec) : void
+    public function setSendTimeoutSec(float $sendTimeoutSec): void
     {
         $this->sendTimeoutSec = $sendTimeoutSec;
     }
 
-    public function setSendTimeoutUsec(float $sendTimeoutUsec) : void
+    public function setSendTimeoutUsec(float $sendTimeoutUsec): void
     {
         $this->sendTimeoutUsec = $sendTimeoutUsec;
     }
 
-    public function setRecvTimeoutSec(float $recvTimeoutSec) : void
+    public function setRecvTimeoutSec(float $recvTimeoutSec): void
     {
         $this->recvTimeoutSec = $recvTimeoutSec;
     }
 
-    public function setRecvTimeoutUsec(float $recvTimeoutUsec) : void
+    public function setRecvTimeoutUsec(float $recvTimeoutUsec): void
     {
         $this->recvTimeoutUsec = $recvTimeoutUsec;
     }
 
-    public function setMaxWriteAttempts(int $number) : void
+    public function setMaxWriteAttempts(int $number): void
     {
         $this->maxWriteAttempts = $number;
     }
@@ -107,7 +107,7 @@ abstract class CommonSocket
     /**
      * @throws Exception
      */
-    protected function createStream() : void
+    protected function createStream(): void
     {
         if (trim($this->host) === '') {
             throw new Exception('Cannot open null host.');
@@ -213,7 +213,7 @@ abstract class CommonSocket
      *
      * @throws Exception
      */
-    public function readBlocking(int $length) : string
+    public function readBlocking(int $length): string
     {
         if ($length > self::READ_MAX_LENGTH) {
             throw new Exception('Invalid length given, it should be lesser than or equals to ' . self:: READ_MAX_LENGTH);
@@ -270,7 +270,7 @@ abstract class CommonSocket
      *
      * @throws Exception
      */
-    public function writeBlocking(string $buffer) : int
+    public function writeBlocking(string $buffer): int
     {
         // fwrite to a socket may be partial, so loop until we
         // are done with the entire buffer
@@ -326,7 +326,7 @@ abstract class CommonSocket
         return $bytesWritten;
     }
 
-    abstract public function close() : void;
+    abstract public function close(): void;
 
     abstract public function connect(): void;
 }

--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -111,7 +111,7 @@ abstract class CommonSocket
      */
     protected function createStream(): void
     {
-        if (trim($this->host) === '') {
+        if (\trim($this->host) === '') {
             throw new Exception('Cannot open null host.');
         }
 
@@ -119,13 +119,13 @@ abstract class CommonSocket
             throw new Exception('Cannot open without port.');
         }
 
-        $remoteSocket = sprintf('tcp://%s:%s', $this->host, $this->port);
-        $context      = stream_context_create([]);
+        $remoteSocket = \sprintf('tcp://%s:%s', $this->host, $this->port);
+        $context      = \stream_context_create([]);
 
         if ($this->config !== null && $this->config->getSslEnable()) { // ssl connection
-            $remoteSocket = sprintf('ssl://%s:%s', $this->host, $this->port);
+            $remoteSocket = \sprintf('ssl://%s:%s', $this->host, $this->port);
 
-            $context = stream_context_create(
+            $context = \stream_context_create(
                 [
                     'ssl' => [
                         'local_cert'  => $this->config->getSslLocalCert(),
@@ -143,7 +143,7 @@ abstract class CommonSocket
 
         if (! \is_resource($this->stream)) {
             throw new Exception(
-                sprintf('Could not connect to %s:%d (%s [%d])', $this->host, $this->port, $errstr, $errno)
+                \sprintf('Could not connect to %s:%d (%s [%d])', $this->host, $this->port, $errstr, $errno)
             );
         }
 
@@ -166,12 +166,12 @@ abstract class CommonSocket
      */
     protected function createSocket(string $remoteSocket, $context, ?int &$errno, ?string &$errstr)
     {
-        return stream_socket_client(
+        return \stream_socket_client(
             $remoteSocket,
             $errno,
             $errstr,
             $this->sendTimeoutSec + ($this->sendTimeoutUsec / 1000000),
-            STREAM_CLIENT_CONNECT,
+            \STREAM_CLIENT_CONNECT,
             $context
         );
     }
@@ -200,10 +200,10 @@ abstract class CommonSocket
         $null = null;
 
         if ($isRead) {
-            return @stream_select($sockets, $null, $null, $timeoutSec, $timeoutUsec);
+            return @\stream_select($sockets, $null, $null, $timeoutSec, $timeoutUsec);
         }
 
-        return @stream_select($null, $sockets, $null, $timeoutSec, $timeoutUsec);
+        return @\stream_select($null, $sockets, $null, $timeoutSec, $timeoutUsec);
     }
 
     /**
@@ -217,7 +217,7 @@ abstract class CommonSocket
      */
     protected function getMetaData(): array
     {
-        return stream_get_meta_data($this->stream);
+        return \stream_get_meta_data($this->stream);
     }
 
     /**
@@ -256,11 +256,11 @@ abstract class CommonSocket
         $data           = $chunk = '';
 
         while ($remainingBytes > 0) {
-            $chunk = fread($this->stream, $remainingBytes);
+            $chunk = \fread($this->stream, $remainingBytes);
 
-            if ($chunk === false || strlen($chunk) === 0) {
+            if ($chunk === false || \strlen($chunk) === 0) {
                 // Zero bytes because of EOF?
-                if (feof($this->stream)) {
+                if (\feof($this->stream)) {
                     $this->close();
                     throw new Exception('Unexpected EOF while reading ' . $length . ' bytes from stream (no data)');
                 }
@@ -274,7 +274,7 @@ abstract class CommonSocket
             }
 
             $data           .= $chunk;
-            $remainingBytes -= strlen($chunk);
+            $remainingBytes -= \strlen($chunk);
         }
 
         return $data;
@@ -292,7 +292,7 @@ abstract class CommonSocket
         $failedAttempts = 0;
         $bytesWritten   = 0;
 
-        $bytesToWrite = strlen($buffer);
+        $bytesToWrite = \strlen($buffer);
 
         while ($bytesWritten < $bytesToWrite) {
             // wait for stream to become available for writing
@@ -313,14 +313,14 @@ abstract class CommonSocket
 
             if ($bytesToWrite - $bytesWritten > self::MAX_WRITE_BUFFER) {
                 // write max buffer size
-                $wrote = fwrite($this->stream, substr($buffer, $bytesWritten, self::MAX_WRITE_BUFFER));
+                $wrote = \fwrite($this->stream, \substr($buffer, $bytesWritten, self::MAX_WRITE_BUFFER));
             } else {
                 // write remaining buffer bytes to stream
-                $wrote = fwrite($this->stream, substr($buffer, $bytesWritten));
+                $wrote = \fwrite($this->stream, \substr($buffer, $bytesWritten));
             }
 
             if ($wrote === -1 || $wrote === false) {
-                throw new Exception\Socket('Could not write ' . strlen($buffer) . ' bytes to stream, completed writing only ' . $bytesWritten . ' bytes');
+                throw new Exception\Socket('Could not write ' . \strlen($buffer) . ' bytes to stream, completed writing only ' . $bytesWritten . ' bytes');
             }
 
             if ($wrote === 0) {
@@ -328,7 +328,7 @@ abstract class CommonSocket
                 $failedAttempts++;
 
                 if ($failedAttempts > $this->maxWriteAttempts) {
-                    throw new Exception\Socket('After ' . $failedAttempts . ' attempts could not write ' . strlen($buffer) . ' bytes to stream, completed writing only ' . $bytesWritten . ' bytes');
+                    throw new Exception\Socket('After ' . $failedAttempts . ' attempts could not write ' . \strlen($buffer) . ' bytes to stream, completed writing only ' . $bytesWritten . ' bytes');
                 }
             } else {
                 // If we wrote something, reset our failed attempt counter

--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -231,7 +231,7 @@ abstract class CommonSocket
     public function readBlocking(int $length): string
     {
         if ($length > self::READ_MAX_LENGTH) {
-            throw new Exception('Invalid length given, it should be lesser than or equals to ' . self:: READ_MAX_LENGTH);
+            throw new Exception('Invalid length given, it should be lesser than or equals to ' . self::READ_MAX_LENGTH);
         }
 
         $readable = $this->select([$this->stream], $this->recvTimeoutSec, $this->recvTimeoutUsec);

--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -283,11 +283,11 @@ abstract class CommonSocket
             // wait for stream to become available for writing
             $writable = $this->select([$this->stream], $this->sendTimeoutSec, $this->sendTimeoutUsec, false);
 
-            if (false === $writable) {
+            if ($writable === false) {
                 throw new Exception\Socket('Could not write ' . $bytesToWrite . ' bytes to stream');
             }
 
-            if (0 === $writable) {
+            if ($writable === 0) {
                 $res = $this->getMetaData();
                 if (! empty($res['timed_out'])) {
                     throw new Exception('Timed out writing ' . $bytesToWrite . ' bytes to stream after writing ' . $bytesWritten . ' bytes');

--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -16,28 +16,28 @@ abstract class CommonSocket
     /**
      * Send timeout in seconds.
      *
-     * @var float
+     * @var int
      */
     protected $sendTimeoutSec = 0;
 
     /**
      * Send timeout in microseconds.
      *
-     * @var float
+     * @var int
      */
     protected $sendTimeoutUsec = 100000;
 
     /**
      * Recv timeout in seconds
      *
-     * @var float
+     * @var int
      */
     protected $recvTimeoutSec = 0;
 
     /**
      * Recv timeout in microseconds
      *
-     * @var float
+     * @var int
      */
     protected $recvTimeoutUsec = 750000;
 
@@ -79,22 +79,22 @@ abstract class CommonSocket
         $this->saslProvider = $saslProvider;
     }
 
-    public function setSendTimeoutSec(float $sendTimeoutSec): void
+    public function setSendTimeoutSec(int $sendTimeoutSec): void
     {
         $this->sendTimeoutSec = $sendTimeoutSec;
     }
 
-    public function setSendTimeoutUsec(float $sendTimeoutUsec): void
+    public function setSendTimeoutUsec(int $sendTimeoutUsec): void
     {
         $this->sendTimeoutUsec = $sendTimeoutUsec;
     }
 
-    public function setRecvTimeoutSec(float $recvTimeoutSec): void
+    public function setRecvTimeoutSec(int $recvTimeoutSec): void
     {
         $this->recvTimeoutSec = $recvTimeoutSec;
     }
 
-    public function setRecvTimeoutUsec(float $recvTimeoutUsec): void
+    public function setRecvTimeoutUsec(int $recvTimeoutUsec): void
     {
         $this->recvTimeoutUsec = $recvTimeoutUsec;
     }
@@ -157,6 +157,10 @@ abstract class CommonSocket
      * Because `stream_socket_client` in stream wrapper mock no effect, if don't create this function will never be testable
      *
      * @codeCoverageIgnore
+     *
+     * @param resource $context
+     *
+     * @return resource
      */
     protected function createSocket(string $remoteSocket, $context, ?int &$errno, ?string &$errstr)
     {
@@ -170,6 +174,9 @@ abstract class CommonSocket
         );
     }
 
+    /**
+     * @return resource
+     */
     public function getSocket()
     {
         return $this->stream;
@@ -181,8 +188,12 @@ abstract class CommonSocket
      * Because `stream_select` in stream wrapper mock no effect, if don't create this function will never be testable
      *
      * @codeCoverageIgnore
+     *
+     * @param resource[] $sockets
+     *
+     * @return int|bool
      */
-    protected function select(array $sockets, float $timeoutSec, float $timeoutUsec, bool $isRead = true)
+    protected function select(array $sockets, int $timeoutSec, int $timeoutUsec, bool $isRead = true)
     {
         $null = null;
 
@@ -199,6 +210,8 @@ abstract class CommonSocket
      * Because `stream_get_meta_data` in stream wrapper mock no effect, if don't create this function will never be testable
      *
      * @codeCoverageIgnore
+     *
+     * @return mixed[]
      */
     protected function getMetaData(): array
     {
@@ -329,4 +342,16 @@ abstract class CommonSocket
     abstract public function close(): void;
 
     abstract public function connect(): void;
+
+    /**
+     * @return void|int
+     */
+    abstract public function write(?string $data = null);
+
+    /**
+     * @param string|int $data
+     *
+     * @return mixed
+     */
+    abstract public function read($data);
 }

--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -139,7 +139,7 @@ abstract class CommonSocket
 
         $this->stream = $this->createSocket($remoteSocket, $context, $errno, $errstr);
 
-        if ($this->stream === false) {
+        if (! \is_resource($this->stream)) {
             throw new Exception(
                 sprintf('Could not connect to %s:%d (%s [%d])', $this->host, $this->port, $errstr, $errno)
             );

--- a/src/Config.php
+++ b/src/Config.php
@@ -43,14 +43,14 @@ abstract class Config
         self::SECURITY_PROTOCOL_PLAINTEXT,
         self::SECURITY_PROTOCOL_SSL,
         self::SECURITY_PROTOCOL_SASL_PLAINTEXT,
-        self::SECURITY_PROTOCOL_SASL_SSL
+        self::SECURITY_PROTOCOL_SASL_SSL,
     ];
 
     private const ALLOW_MECHANISMS = [
         self::SASL_MECHANISMS_PLAIN,
         self::SASL_MECHANISMS_GSSAPI,
         self::SASL_MECHANISMS_SCRAM_SHA_256,
-        self::SASL_MECHANISMS_SCRAM_SHA_512
+        self::SASL_MECHANISMS_SCRAM_SHA_512,
     ];
 
     protected static $options = [];

--- a/src/Config.php
+++ b/src/Config.php
@@ -53,8 +53,14 @@ abstract class Config
         self::SASL_MECHANISMS_SCRAM_SHA_512,
     ];
 
+    /**
+     * @var mixed[]
+     */
     protected static $options = [];
 
+    /**
+     * @var mixed[]
+     */
     private static $defaults = [
         'clientId'                  => 'kafka-php',
         'brokerVersion'             => '0.10.1.0',
@@ -78,10 +84,23 @@ abstract class Config
         'saslPrincipal'             => '',
     ];
 
-    public function __call($name, $args)
+    /**
+     * @param mixed[] $args
+     *
+     * @return bool|mixed
+     */
+    public function __call(string $name, array $args)
     {
-        if (strpos($name, 'get') === 0 || strpos($name, 'iet') === 0) {
-            $option = strtolower(substr($name, 3, 1)) . substr($name, 4);
+        $isGetter = strpos($name, 'get') === 0 || strpos($name, 'iet') === 0;
+        $isSetter = strpos($name, 'set') === 0;
+
+        if (! $isGetter && ! $isSetter) {
+            return false;
+        }
+
+        $option = lcfirst(substr($name, 3));
+
+        if ($isGetter) {
             if (isset(self::$options[$option])) {
                 return self::$options[$option];
             }
@@ -89,21 +108,22 @@ abstract class Config
             if (isset(self::$defaults[$option])) {
                 return self::$defaults[$option];
             }
+
             if (isset(static::$defaults[$option])) {
                 return static::$defaults[$option];
             }
+
             return false;
         }
 
-        if (strpos($name, 'set') === 0) {
-            if (count($args) !== 1) {
-                return false;
-            }
-            $option                   = strtolower(substr($name, 3, 1)) . substr($name, 4);
-            static::$options[$option] = $args[0];
-            // check todo
-            return true;
+        if (count($args) !== 1) {
+            return false;
         }
+
+        static::$options[$option] = array_shift($args);
+
+        // check todo
+        return true;
     }
 
     public function setClientId(string $val): void
@@ -153,6 +173,9 @@ abstract class Config
         static::$options = [];
     }
 
+    /**
+     * @param int|float|string $messageMaxBytes
+     */
     public function setMessageMaxBytes($messageMaxBytes): void
     {
         if (! is_numeric($messageMaxBytes) || $messageMaxBytes < 1000 || $messageMaxBytes > 1000000000) {
@@ -161,6 +184,9 @@ abstract class Config
         static::$options['messageMaxBytes'] = $messageMaxBytes;
     }
 
+    /**
+     * @param int|float|string $metadataRequestTimeoutMs
+     */
     public function setMetadataRequestTimeoutMs($metadataRequestTimeoutMs): void
     {
         if (! is_numeric($metadataRequestTimeoutMs) || $metadataRequestTimeoutMs < 10
@@ -170,6 +196,9 @@ abstract class Config
         static::$options['metadataRequestTimeoutMs'] = $metadataRequestTimeoutMs;
     }
 
+    /**
+     * @param int|float|string $metadataRefreshIntervalMs
+     */
     public function setMetadataRefreshIntervalMs($metadataRefreshIntervalMs): void
     {
         if (! is_numeric($metadataRefreshIntervalMs) || $metadataRefreshIntervalMs < 10
@@ -179,6 +208,9 @@ abstract class Config
         static::$options['metadataRefreshIntervalMs'] = $metadataRefreshIntervalMs;
     }
 
+    /**
+     * @param int|float|string $metadataMaxAgeMs
+     */
     public function setMetadataMaxAgeMs($metadataMaxAgeMs): void
     {
         if (! is_numeric($metadataMaxAgeMs) || $metadataMaxAgeMs < 1 || $metadataMaxAgeMs > 86400000) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -96,7 +96,7 @@ abstract class Config
         }
 
         if (strpos($name, 'set') === 0) {
-            if (count($args) != 1) {
+            if (count($args) !== 1) {
                 return false;
             }
             $option                   = strtolower(substr($name, 3, 1)) . substr($name, 4);

--- a/src/Config.php
+++ b/src/Config.php
@@ -7,10 +7,10 @@ namespace Kafka;
  * @method string getClientId()
  * @method string getBrokerVersion()
  * @method string getMetadataBrokerList()
- * @method string getMessageMaxBytes()
- * @method string getMetadataRequestTimeoutMs()
- * @method string getMetadataRefreshIntervalMs()
- * @method string getMetadataMaxAgeMs()
+ * @method int getMessageMaxBytes()
+ * @method int getMetadataRequestTimeoutMs()
+ * @method int getMetadataRefreshIntervalMs()
+ * @method int getMetadataMaxAgeMs()
  * @method string getSecurityProtocol()
  * @method bool getSslEnable()
  * @method void setSslEnable(bool $sslEnable)
@@ -67,9 +67,9 @@ abstract class Config
         'clientId'                  => 'kafka-php',
         'brokerVersion'             => '0.10.1.0',
         'metadataBrokerList'        => '',
-        'messageMaxBytes'           => '1000000',
-        'metadataRequestTimeoutMs'  => '60000',
-        'metadataRefreshIntervalMs' => '300000',
+        'messageMaxBytes'           => 1000000,
+        'metadataRequestTimeoutMs'  => 60000,
+        'metadataRefreshIntervalMs' => 300000,
         'metadataMaxAgeMs'          => -1,
         'securityProtocol'          => self::SECURITY_PROTOCOL_PLAINTEXT,
         'sslEnable'                 => false, // this config item will override, don't config it.
@@ -128,6 +128,9 @@ abstract class Config
         return true;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setClientId(string $val): void
     {
         $client = \trim($val);
@@ -139,6 +142,9 @@ abstract class Config
         static::$options['clientId'] = $client;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setBrokerVersion(string $version): void
     {
         $version = \trim($version);
@@ -150,6 +156,9 @@ abstract class Config
         static::$options['brokerVersion'] = $version;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setMetadataBrokerList(string $brokerList): void
     {
         $brokerList = \trim($brokerList);
@@ -176,87 +185,100 @@ abstract class Config
     }
 
     /**
-     * @param int|float|string $messageMaxBytes
+     * @throws Exception\Config
      */
-    public function setMessageMaxBytes($messageMaxBytes): void
+    public function setMessageMaxBytes(int $messageMaxBytes): void
     {
-        if (! \is_numeric($messageMaxBytes) || $messageMaxBytes < 1000 || $messageMaxBytes > 1000000000) {
+        if ($messageMaxBytes < 1000 || $messageMaxBytes > 1000000000) {
             throw new Exception\Config('Set message max bytes value is invalid, must set it 1000 .. 1000000000');
         }
         static::$options['messageMaxBytes'] = $messageMaxBytes;
     }
 
     /**
-     * @param int|float|string $metadataRequestTimeoutMs
+     * @throws Exception\Config
      */
-    public function setMetadataRequestTimeoutMs($metadataRequestTimeoutMs): void
+    public function setMetadataRequestTimeoutMs(int $metadataRequestTimeoutMs): void
     {
-        if (! \is_numeric($metadataRequestTimeoutMs) || $metadataRequestTimeoutMs < 10
-            || $metadataRequestTimeoutMs > 900000) {
+        if ($metadataRequestTimeoutMs < 10 || $metadataRequestTimeoutMs > 900000) {
             throw new Exception\Config('Set metadata request timeout value is invalid, must set it 10 .. 900000');
         }
         static::$options['metadataRequestTimeoutMs'] = $metadataRequestTimeoutMs;
     }
 
     /**
-     * @param int|float|string $metadataRefreshIntervalMs
+     * @throws Exception\Config
      */
-    public function setMetadataRefreshIntervalMs($metadataRefreshIntervalMs): void
+    public function setMetadataRefreshIntervalMs(int $metadataRefreshIntervalMs): void
     {
-        if (! \is_numeric($metadataRefreshIntervalMs) || $metadataRefreshIntervalMs < 10
-            || $metadataRefreshIntervalMs > 3600000) {
+        if ($metadataRefreshIntervalMs < 10 || $metadataRefreshIntervalMs > 3600000) {
             throw new Exception\Config('Set metadata refresh interval value is invalid, must set it 10 .. 3600000');
         }
         static::$options['metadataRefreshIntervalMs'] = $metadataRefreshIntervalMs;
     }
 
     /**
-     * @param int|float|string $metadataMaxAgeMs
+     * @throws Exception\Config
      */
-    public function setMetadataMaxAgeMs($metadataMaxAgeMs): void
+    public function setMetadataMaxAgeMs(int $metadataMaxAgeMs): void
     {
-        if (! \is_numeric($metadataMaxAgeMs) || $metadataMaxAgeMs < 1 || $metadataMaxAgeMs > 86400000) {
+        if ($metadataMaxAgeMs < 1 || $metadataMaxAgeMs > 86400000) {
             throw new Exception\Config('Set metadata max age value is invalid, must set it 1 .. 86400000');
         }
         static::$options['metadataMaxAgeMs'] = $metadataMaxAgeMs;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setSslLocalCert(string $localCert): void
     {
-        if (! \file_exists($localCert) || ! \is_file($localCert)) {
+        if (! \is_file($localCert)) {
             throw new Exception\Config('Set ssl local cert file is invalid');
         }
 
         static::$options['sslLocalCert'] = $localCert;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setSslLocalPk(string $localPk): void
     {
-        if (! \file_exists($localPk) || ! \is_file($localPk)) {
+        if (! \is_file($localPk)) {
             throw new Exception\Config('Set ssl local private key file is invalid');
         }
 
         static::$options['sslLocalPk'] = $localPk;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setSslCafile(string $cafile): void
     {
-        if (! \file_exists($cafile) || ! \is_file($cafile)) {
+        if (! \is_file($cafile)) {
             throw new Exception\Config('Set ssl ca file is invalid');
         }
 
         static::$options['sslCafile'] = $cafile;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setSaslKeytab(string $keytab): void
     {
-        if (! \file_exists($keytab) || ! \is_file($keytab)) {
+        if (! \is_file($keytab)) {
             throw new Exception\Config('Set sasl gssapi keytab file is invalid');
         }
 
         static::$options['saslKeytab'] = $keytab;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setSecurityProtocol(string $protocol): void
     {
         if (! \in_array($protocol, self::ALLOW_SECURITY_PROTOCOLS, true)) {
@@ -266,6 +288,9 @@ abstract class Config
         static::$options['securityProtocol'] = $protocol;
     }
 
+    /**
+     * @throws Exception\Config
+     */
     public function setSaslMechanism(string $mechanism): void
     {
         if (! \in_array($mechanism, self::ALLOW_MECHANISMS, true)) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -93,14 +93,14 @@ abstract class Config
      */
     public function __call(string $name, array $args)
     {
-        $isGetter = strpos($name, 'get') === 0 || strpos($name, 'iet') === 0;
-        $isSetter = strpos($name, 'set') === 0;
+        $isGetter = \strpos($name, 'get') === 0 || \strpos($name, 'iet') === 0;
+        $isSetter = \strpos($name, 'set') === 0;
 
         if (! $isGetter && ! $isSetter) {
             return false;
         }
 
-        $option = lcfirst(substr($name, 3));
+        $option = \lcfirst(\substr($name, 3));
 
         if ($isGetter) {
             if (isset(self::$options[$option])) {
@@ -118,11 +118,11 @@ abstract class Config
             return false;
         }
 
-        if (count($args) !== 1) {
+        if (\count($args) !== 1) {
             return false;
         }
 
-        static::$options[$option] = array_shift($args);
+        static::$options[$option] = \array_shift($args);
 
         // check todo
         return true;
@@ -130,7 +130,7 @@ abstract class Config
 
     public function setClientId(string $val): void
     {
-        $client = trim($val);
+        $client = \trim($val);
 
         if ($client === '') {
             throw new Exception\Config('Set clientId value is invalid, must is not empty string.');
@@ -141,9 +141,9 @@ abstract class Config
 
     public function setBrokerVersion(string $version): void
     {
-        $version = trim($version);
+        $version = \trim($version);
 
-        if ($version === '' || version_compare($version, '0.8.0', '<')) {
+        if ($version === '' || \version_compare($version, '0.8.0', '<')) {
             throw new Exception\Config('Set broker version value is invalid, must is not empty string and gt 0.8.0.');
         }
 
@@ -152,12 +152,12 @@ abstract class Config
 
     public function setMetadataBrokerList(string $brokerList): void
     {
-        $brokerList = trim($brokerList);
+        $brokerList = \trim($brokerList);
 
-        $brokers = array_filter(
-            explode(',', $brokerList),
+        $brokers = \array_filter(
+            \explode(',', $brokerList),
             function (string $broker): bool {
-                return preg_match('/^(.*:[\d]+)$/', $broker) === 1;
+                return \preg_match('/^(.*:[\d]+)$/', $broker) === 1;
             }
         );
 
@@ -180,7 +180,7 @@ abstract class Config
      */
     public function setMessageMaxBytes($messageMaxBytes): void
     {
-        if (! is_numeric($messageMaxBytes) || $messageMaxBytes < 1000 || $messageMaxBytes > 1000000000) {
+        if (! \is_numeric($messageMaxBytes) || $messageMaxBytes < 1000 || $messageMaxBytes > 1000000000) {
             throw new Exception\Config('Set message max bytes value is invalid, must set it 1000 .. 1000000000');
         }
         static::$options['messageMaxBytes'] = $messageMaxBytes;
@@ -191,7 +191,7 @@ abstract class Config
      */
     public function setMetadataRequestTimeoutMs($metadataRequestTimeoutMs): void
     {
-        if (! is_numeric($metadataRequestTimeoutMs) || $metadataRequestTimeoutMs < 10
+        if (! \is_numeric($metadataRequestTimeoutMs) || $metadataRequestTimeoutMs < 10
             || $metadataRequestTimeoutMs > 900000) {
             throw new Exception\Config('Set metadata request timeout value is invalid, must set it 10 .. 900000');
         }
@@ -203,7 +203,7 @@ abstract class Config
      */
     public function setMetadataRefreshIntervalMs($metadataRefreshIntervalMs): void
     {
-        if (! is_numeric($metadataRefreshIntervalMs) || $metadataRefreshIntervalMs < 10
+        if (! \is_numeric($metadataRefreshIntervalMs) || $metadataRefreshIntervalMs < 10
             || $metadataRefreshIntervalMs > 3600000) {
             throw new Exception\Config('Set metadata refresh interval value is invalid, must set it 10 .. 3600000');
         }
@@ -215,7 +215,7 @@ abstract class Config
      */
     public function setMetadataMaxAgeMs($metadataMaxAgeMs): void
     {
-        if (! is_numeric($metadataMaxAgeMs) || $metadataMaxAgeMs < 1 || $metadataMaxAgeMs > 86400000) {
+        if (! \is_numeric($metadataMaxAgeMs) || $metadataMaxAgeMs < 1 || $metadataMaxAgeMs > 86400000) {
             throw new Exception\Config('Set metadata max age value is invalid, must set it 1 .. 86400000');
         }
         static::$options['metadataMaxAgeMs'] = $metadataMaxAgeMs;
@@ -223,7 +223,7 @@ abstract class Config
 
     public function setSslLocalCert(string $localCert): void
     {
-        if (! file_exists($localCert) || ! is_file($localCert)) {
+        if (! \file_exists($localCert) || ! \is_file($localCert)) {
             throw new Exception\Config('Set ssl local cert file is invalid');
         }
 
@@ -232,7 +232,7 @@ abstract class Config
 
     public function setSslLocalPk(string $localPk): void
     {
-        if (! file_exists($localPk) || ! is_file($localPk)) {
+        if (! \file_exists($localPk) || ! \is_file($localPk)) {
             throw new Exception\Config('Set ssl local private key file is invalid');
         }
 
@@ -241,7 +241,7 @@ abstract class Config
 
     public function setSslCafile(string $cafile): void
     {
-        if (! file_exists($cafile) || ! is_file($cafile)) {
+        if (! \file_exists($cafile) || ! \is_file($cafile)) {
             throw new Exception\Config('Set ssl ca file is invalid');
         }
 
@@ -250,7 +250,7 @@ abstract class Config
 
     public function setSaslKeytab(string $keytab): void
     {
-        if (! file_exists($keytab) || ! is_file($keytab)) {
+        if (! \file_exists($keytab) || ! \is_file($keytab)) {
             throw new Exception\Config('Set sasl gssapi keytab file is invalid');
         }
 

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -31,9 +31,7 @@ class Consumer
      *
      * @access public
      *
-     * @param callable|null $consumer
      *
-     * @return void
      */
     public function start(?callable $consumer = null): void
     {

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Amp\Loop;

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -4,11 +4,12 @@ namespace Kafka;
 use Amp\Loop;
 use Kafka\Consumer\Process;
 use Kafka\Consumer\StopStrategy;
+use Psr\Log\LoggerAwareTrait;
 
 class Consumer
 {
-    use \Psr\Log\LoggerAwareTrait;
-    use \Kafka\LoggerTrait;
+    use LoggerAwareTrait;
+    use LoggerTrait;
 
     /**
      * @var StopStrategy|null

--- a/src/Consumer/Assignment.php
+++ b/src/Consumer/Assignment.php
@@ -97,7 +97,7 @@ class Assignment
         $broker = Broker::getInstance();
         $topics = $broker->getTopics();
 
-        $memberCount = count($result);
+        $memberCount = \count($result);
 
         $count   = 0;
         $members = [];

--- a/src/Consumer/Assignment.php
+++ b/src/Consumer/Assignment.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Consumer;
 
 use Kafka\Broker;

--- a/src/Consumer/Assignment.php
+++ b/src/Consumer/Assignment.php
@@ -1,8 +1,8 @@
 <?php
 namespace Kafka\Consumer;
 
-use Kafka\SingletonTrait;
 use Kafka\Broker;
+use Kafka\SingletonTrait;
 
 class Assignment
 {

--- a/src/Consumer/Assignment.php
+++ b/src/Consumer/Assignment.php
@@ -1,9 +1,12 @@
 <?php
 namespace Kafka\Consumer;
 
+use Kafka\SingletonTrait;
+use Kafka\Broker;
+
 class Assignment
 {
-    use \Kafka\SingletonTrait;
+    use SingletonTrait;
     
     private $memberId = '';
 
@@ -52,7 +55,7 @@ class Assignment
 
     public function assign($result)
     {
-        $broker = \Kafka\Broker::getInstance();
+        $broker = Broker::getInstance();
         $topics = $broker->getTopics();
 
         $memberCount = count($result);

--- a/src/Consumer/Assignment.php
+++ b/src/Consumer/Assignment.php
@@ -82,7 +82,7 @@ class Assignment
             $item   = [
                 'version' => 0,
                 'member_id' => $member['memberId'],
-                'assignments' => isset($members[$key]) ? $members[$key] : []
+                'assignments' => isset($members[$key]) ? $members[$key] : [],
             ];
             $data[] = $item;
         }

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -52,35 +52,37 @@ class Process
         if ($this->logger) {
             $this->state->setLogger($this->logger);
         }
-        $this->state->setCallback([
-            State::REQUEST_METADATA => function (): void {
-                $this->syncMeta();
-            },
-            State::REQUEST_GETGROUP => function (): void {
-                $this->getGroupBrokerId();
-            },
-            State::REQUEST_JOINGROUP => function (): void {
-                $this->joinGroup();
-            },
-            State::REQUEST_SYNCGROUP => function (): void {
-                $this->syncGroup();
-            },
-            State::REQUEST_HEARTGROUP => function (): void {
-                $this->heartbeat();
-            },
-            State::REQUEST_OFFSET => function (): array {
-                return $this->offset();
-            },
-            State::REQUEST_FETCH_OFFSET => function (): void {
-                $this->fetchOffset();
-            },
-            State::REQUEST_FETCH => function (): array {
-                return $this->fetch();
-            },
-            State::REQUEST_COMMIT_OFFSET => function (): void {
-                $this->commit();
-            },
-        ]);
+        $this->state->setCallback(
+            [
+                State::REQUEST_METADATA      => function (): void {
+                    $this->syncMeta();
+                },
+                State::REQUEST_GETGROUP      => function (): void {
+                    $this->getGroupBrokerId();
+                },
+                State::REQUEST_JOINGROUP     => function (): void {
+                    $this->joinGroup();
+                },
+                State::REQUEST_SYNCGROUP     => function (): void {
+                    $this->syncGroup();
+                },
+                State::REQUEST_HEARTGROUP    => function (): void {
+                    $this->heartbeat();
+                },
+                State::REQUEST_OFFSET        => function (): array {
+                    return $this->offset();
+                },
+                State::REQUEST_FETCH_OFFSET  => function (): void {
+                    $this->fetchOffset();
+                },
+                State::REQUEST_FETCH         => function (): array {
+                    return $this->fetch();
+                },
+                State::REQUEST_COMMIT_OFFSET => function (): void {
+                    $this->commit();
+                },
+            ]
+        );
         $this->state->init();
     }
 

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -104,11 +104,11 @@ class Process
      */
     protected function processRequest(string $data, int $fd): void
     {
-        $correlationId = ProtocolTool::unpack(ProtocolTool::BIT_B32, substr($data, 0, 4));
+        $correlationId = ProtocolTool::unpack(ProtocolTool::BIT_B32, \substr($data, 0, 4));
 
         switch ($correlationId) {
             case Protocol::METADATA_REQUEST:
-                $result = Protocol::decode(Protocol::METADATA_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::METADATA_REQUEST, \substr($data, 4));
 
                 if (! isset($result['brokers'], $result['topics'])) {
                     $this->error('Get metadata is fail, brokers or topics is null.');
@@ -123,7 +123,7 @@ class Process
 
                 break;
             case Protocol::GROUP_COORDINATOR_REQUEST:
-                $result = Protocol::decode(Protocol::GROUP_COORDINATOR_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::GROUP_COORDINATOR_REQUEST, \substr($data, 4));
 
                 if (! isset($result['errorCode'], $result['coordinatorId']) || $result['errorCode'] !== Protocol::NO_ERROR) {
                     $this->state->failRun(State::REQUEST_GETGROUP);
@@ -138,7 +138,7 @@ class Process
 
                 break;
             case Protocol::JOIN_GROUP_REQUEST:
-                $result = Protocol::decode(Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::JOIN_GROUP_REQUEST, \substr($data, 4));
                 if (isset($result['errorCode']) && $result['errorCode'] === Protocol::NO_ERROR) {
                     $this->succJoinGroup($result);
                     break;
@@ -147,7 +147,7 @@ class Process
                 $this->failJoinGroup($result['errorCode']);
                 break;
             case Protocol::SYNC_GROUP_REQUEST:
-                $result = Protocol::decode(Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::SYNC_GROUP_REQUEST, \substr($data, 4));
                 if (isset($result['errorCode']) && $result['errorCode'] === Protocol::NO_ERROR) {
                     $this->succSyncGroup($result);
                     break;
@@ -156,7 +156,7 @@ class Process
                 $this->failSyncGroup($result['errorCode']);
                 break;
             case Protocol::HEART_BEAT_REQUEST:
-                $result = Protocol::decode(Protocol::HEART_BEAT_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::HEART_BEAT_REQUEST, \substr($data, 4));
                 if (isset($result['errorCode']) && $result['errorCode'] === Protocol::NO_ERROR) {
                     $this->state->succRun(State::REQUEST_HEARTGROUP);
                     break;
@@ -165,19 +165,19 @@ class Process
                 $this->failHeartbeat($result['errorCode']);
                 break;
             case Protocol::OFFSET_REQUEST:
-                $result = Protocol::decode(Protocol::OFFSET_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::OFFSET_REQUEST, \substr($data, 4));
                 $this->succOffset($result, $fd);
                 break;
             case ProtocolTool::OFFSET_FETCH_REQUEST:
-                $result = Protocol::decode(Protocol::OFFSET_FETCH_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::OFFSET_FETCH_REQUEST, \substr($data, 4));
                 $this->succFetchOffset($result);
                 break;
             case ProtocolTool::FETCH_REQUEST:
-                $result = Protocol::decode(Protocol::FETCH_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::FETCH_REQUEST, \substr($data, 4));
                 $this->succFetch($result, $fd);
                 break;
             case ProtocolTool::OFFSET_COMMIT_REQUEST:
-                $result = Protocol::decode(Protocol::OFFSET_COMMIT_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::OFFSET_COMMIT_REQUEST, \substr($data, 4));
                 $this->succCommit($result);
                 break;
             default:
@@ -194,17 +194,17 @@ class Process
         $brokerList = $config->getMetadataBrokerList();
         $brokerHost = [];
 
-        foreach (explode(',', $brokerList) as $key => $val) {
-            if (trim($val)) {
+        foreach (\explode(',', $brokerList) as $key => $val) {
+            if (\trim($val)) {
                 $brokerHost[] = $val;
             }
         }
 
-        if (count($brokerHost) === 0) {
+        if (\count($brokerHost) === 0) {
             throw new Exception('No valid broker configured');
         }
 
-        shuffle($brokerHost);
+        \shuffle($brokerHost);
         $broker = $this->getBroker();
 
         foreach ($brokerHost as $host) {
@@ -215,7 +215,7 @@ class Process
             }
 
             $params = $config->getTopics();
-            $this->debug('Start sync metadata request params:' . json_encode($params));
+            $this->debug('Start sync metadata request params:' . \json_encode($params));
             $requestData = Protocol::encode(Protocol::METADATA_REQUEST, $params);
             $socket->write($requestData);
 
@@ -223,7 +223,7 @@ class Process
         }
 
         throw new Exception(
-            sprintf('It was not possible to establish a connection for metadata with the brokers "%s"', $brokerList)
+            \sprintf('It was not possible to establish a connection for metadata with the brokers "%s"', $brokerList)
         );
     }
 
@@ -275,7 +275,7 @@ class Process
 
         $requestData = Protocol::encode(Protocol::JOIN_GROUP_REQUEST, $params);
         $connect->write($requestData);
-        $this->debug('Join group start, params:' . json_encode($params));
+        $this->debug('Join group start, params:' . \json_encode($params));
     }
 
     public function failJoinGroup(int $errorCode): void
@@ -283,7 +283,7 @@ class Process
         $assign   = $this->getAssignment();
         $memberId = $assign->getMemberId();
 
-        $this->error(sprintf('Join group fail, need rejoin, errorCode %d, memberId: %s', $errorCode, $memberId));
+        $this->error(\sprintf('Join group fail, need rejoin, errorCode %d, memberId: %s', $errorCode, $memberId));
         $this->stateConvert($errorCode);
     }
 
@@ -301,7 +301,7 @@ class Process
             $assign->assign($result['members']);
         }
 
-        $this->debug(sprintf('Join group sucess, params: %s', json_encode($result)));
+        $this->debug(\sprintf('Join group sucess, params: %s', \json_encode($result)));
     }
 
     public function syncGroup(): void
@@ -326,14 +326,14 @@ class Process
         ];
 
         $requestData = Protocol::encode(Protocol::SYNC_GROUP_REQUEST, $params);
-        $this->debug('Sync group start, params:' . json_encode($params));
+        $this->debug('Sync group start, params:' . \json_encode($params));
 
         $connect->write($requestData);
     }
 
     public function failSyncGroup(int $errorCode): void
     {
-        $this->error(sprintf('Sync group fail, need rejoin, errorCode %d', $errorCode));
+        $this->error(\sprintf('Sync group fail, need rejoin, errorCode %d', $errorCode));
         $this->stateConvert($errorCode);
     }
 
@@ -342,7 +342,7 @@ class Process
      */
     public function succSyncGroup(array $result): void
     {
-        $this->debug(sprintf('Sync group sucess, params: %s', json_encode($result)));
+        $this->debug(\sprintf('Sync group sucess, params: %s', \json_encode($result)));
         $this->state->succRun(State::REQUEST_SYNCGROUP);
 
         $topics = $this->getBroker()->getTopics();
@@ -383,7 +383,7 @@ class Process
         $assign   = $this->getAssignment();
         $memberId = $assign->getMemberId();
 
-        if (trim($memberId) === '') {
+        if (\trim($memberId) === '') {
             return;
         }
 
@@ -468,7 +468,7 @@ class Process
                     break 2;
                 }
 
-                $offsets[$topic['topicName']][$part['partition']]     = end($part['offsets']);
+                $offsets[$topic['topicName']][$part['partition']]     = \end($part['offsets']);
                 $lastOffsets[$topic['topicName']][$part['partition']] = $part['offsets'][0];
             }
         }
@@ -522,7 +522,7 @@ class Process
      */
     public function succFetchOffset(array $result): void
     {
-        $msg = sprintf('Get current fetch offset sucess, result: %s', json_encode($result));
+        $msg = \sprintf('Get current fetch offset sucess, result: %s', \json_encode($result));
         $this->debug($msg);
 
         $assign  = $this->getAssignment();
@@ -606,7 +606,7 @@ class Process
                 'data' => $data,
             ];
 
-            $this->debug('Fetch message start, params:' . json_encode($params));
+            $this->debug('Fetch message start, params:' . \json_encode($params));
             $requestData = Protocol::encode(Protocol::FETCH_REQUEST, $params);
             $connect->write($requestData);
             $context[] = (int) $connect->getSocket();
@@ -621,7 +621,7 @@ class Process
     public function succFetch(array $result, int $fd): void
     {
         $assign = $this->getAssignment();
-        $this->debug('Fetch success, result:' . json_encode($result));
+        $this->debug('Fetch success, result:' . \json_encode($result));
 
         foreach ($result['topics'] as $topic) {
             foreach ($topic['partitions'] as $part) {
@@ -721,7 +721,7 @@ class Process
             'data' => $data,
         ];
 
-        $this->debug('Commit current fetch offset start, params:' . json_encode($params));
+        $this->debug('Commit current fetch offset start, params:' . \json_encode($params));
         $requestData = Protocol::encode(Protocol::OFFSET_COMMIT_REQUEST, $params);
         $connect->write($requestData);
     }
@@ -731,7 +731,7 @@ class Process
      */
     public function succCommit(array $result): void
     {
-        $this->debug('Commit success, result:' . json_encode($result));
+        $this->debug('Commit success, result:' . \json_encode($result));
         $this->state->succRun(State::REQUEST_COMMIT_OFFSET);
 
         foreach ($result as $topic) {
@@ -776,13 +776,13 @@ class Process
 
         $assign = $this->getAssignment();
 
-        if (in_array($errorCode, $recoverCodes, true)) {
+        if (\in_array($errorCode, $recoverCodes, true)) {
             $this->state->recover();
             $assign->clearOffset();
             return false;
         }
 
-        if (in_array($errorCode, $rejoinCodes, true)) {
+        if (\in_array($errorCode, $rejoinCodes, true)) {
             if ($errorCode === Protocol::UNKNOWN_MEMBER_ID) {
                 $assign->setMemberId('');
             }

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -695,7 +695,7 @@ class Process
             return false;
         }
 
-        if (\Kafka\Protocol::OFFSET_OUT_OF_RANGE === $errorCode) {
+        if ($errorCode === \Kafka\Protocol::OFFSET_OUT_OF_RANGE) {
             $resetOffset = \Kafka\ConsumerConfig::getInstance()->getOffsetReset();
             if ($resetOffset === 'latest') {
                 $offsets = $assign->getLastOffsets();

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -273,7 +273,7 @@ class Process
 
         $requestData = Protocol::encode(Protocol::JOIN_GROUP_REQUEST, $params);
         $connect->write($requestData);
-        $this->debug("Join group start, params:" . json_encode($params));
+        $this->debug('Join group start, params:' . json_encode($params));
     }
 
     public function failJoinGroup(int $errorCode): void
@@ -324,7 +324,7 @@ class Process
         ];
 
         $requestData = Protocol::encode(Protocol::SYNC_GROUP_REQUEST, $params);
-        $this->debug("Sync group start, params:" . json_encode($params));
+        $this->debug('Sync group start, params:' . json_encode($params));
 
         $connect->write($requestData);
     }
@@ -604,7 +604,7 @@ class Process
                 'data' => $data,
             ];
 
-            $this->debug("Fetch message start, params:" . json_encode($params));
+            $this->debug('Fetch message start, params:' . json_encode($params));
             $requestData = Protocol::encode(Protocol::FETCH_REQUEST, $params);
             $connect->write($requestData);
             $context[] = (int) $connect->getSocket();
@@ -719,7 +719,7 @@ class Process
             'data' => $data,
         ];
 
-        $this->debug("Commit current fetch offset start, params:" . json_encode($params));
+        $this->debug('Commit current fetch offset start, params:' . json_encode($params));
         $requestData = Protocol::encode(Protocol::OFFSET_COMMIT_REQUEST, $params);
         $connect->write($requestData);
     }

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -121,7 +121,7 @@ class Process
                 break;
             case \Kafka\Protocol::GROUP_COORDINATOR_REQUEST:
                 $result = \Kafka\Protocol::decode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] == \Kafka\Protocol::NO_ERROR
+                if (isset($result['errorCode']) && $result['errorCode'] === \Kafka\Protocol::NO_ERROR
                 && isset($result['coordinatorId'])) {
                     \Kafka\Broker::getInstance()->setGroupBrokerId($result['coordinatorId']);
                     $this->state->succRun(\Kafka\Consumer\State::REQUEST_GETGROUP);
@@ -131,7 +131,7 @@ class Process
                 break;
             case \Kafka\Protocol::JOIN_GROUP_REQUEST:
                 $result = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] == 0) {
+                if (isset($result['errorCode']) && $result['errorCode'] === 0) {
                     $this->succJoinGroup($result);
                 } else {
                     $this->failJoinGroup($result['errorCode']);
@@ -139,7 +139,7 @@ class Process
                 break;
             case \Kafka\Protocol::SYNC_GROUP_REQUEST:
                 $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] == 0) {
+                if (isset($result['errorCode']) && $result['errorCode'] === 0) {
                     $this->succSyncGroup($result);
                 } else {
                     $this->failSyncGroup($result['errorCode']);
@@ -147,7 +147,7 @@ class Process
                 break;
             case \Kafka\Protocol::HEART_BEAT_REQUEST:
                 $result = \Kafka\Protocol::decode(\Kafka\Protocol::HEART_BEAT_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] == 0) {
+                if (isset($result['errorCode']) && $result['errorCode'] === 0) {
                     $this->state->succRun(\Kafka\Consumer\State::REQUEST_HEARTGROUP);
                 } else {
                     $this->failHeartbeat($result['errorCode']);
@@ -187,7 +187,7 @@ class Process
             }
         }
 
-        if (count($brokerHost) == 0) {
+        if (count($brokerHost) === 0) {
             throw new \Kafka\Exception('No valid broker configured');
         }
 
@@ -241,7 +241,7 @@ class Process
             'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),
             'session_timeout' => \Kafka\ConsumerConfig::getInstance()->getSessionTimeout(),
             'rebalance_timeout' => \Kafka\ConsumerConfig::getInstance()->getRebalanceTimeout(),
-            'member_id' => ($memberId == null) ? '' : $memberId,
+            'member_id' => ($memberId === null) ? '' : $memberId,
             'data' => [
                 [
                     'protocol_name' => 'range',
@@ -271,7 +271,7 @@ class Process
         $assign = \Kafka\Consumer\Assignment::getInstance();
         $assign->setMemberId($result['memberId']);
         $assign->setGenerationId($result['generationId']);
-        if ($result['leaderId'] == $result['memberId']) { // leader assign partition
+        if ($result['leaderId'] === $result['memberId']) { // leader assign partition
             $assigns = $assign->assign($result['members']);
         }
         $msg = sprintf('Join group sucess, params: %s', json_encode($result));
@@ -417,7 +417,7 @@ class Process
         $lastOffsets = \Kafka\Consumer\Assignment::getInstance()->getLastOffsets();
         foreach ($result as $topic) {
             foreach ($topic['partitions'] as $part) {
-                if ($part['errorCode'] != 0) {
+                if ($part['errorCode'] !== 0) {
                     $this->stateConvert($part['errorCode']);
                     break 2;
                 }
@@ -473,7 +473,7 @@ class Process
         $offsets = $assign->getFetchOffsets();
         foreach ($result as $topic) {
             foreach ($topic['partitions'] as $part) {
-                if ($part['errorCode'] != 0) {
+                if ($part['errorCode'] !== 0) {
                     $this->stateConvert($part['errorCode']);
                     break 2;
                 }
@@ -552,7 +552,7 @@ class Process
                     $topic['topicName'],
                     $part['partition'],
                 ];
-                if ($part['errorCode'] != 0) {
+                if ($part['errorCode'] !== 0) {
                     $this->stateConvert($part['errorCode'], $context);
                     continue;
                 }
@@ -593,7 +593,7 @@ class Process
     protected function commit()
     {
         $config = ConsumerConfig::getInstance();
-        if ($config->getConsumeMode() == ConsumerConfig::CONSUME_BEFORE_COMMIT_OFFSET) {
+        if ($config->getConsumeMode() === ConsumerConfig::CONSUME_BEFORE_COMMIT_OFFSET) {
             $this->consumeMessage();
         }
 
@@ -615,7 +615,7 @@ class Process
                     $partitions = $data[$topic['topic_name']]['partitions'];
                 }
                 foreach ($topic['partitions'] as $partId) {
-                    if ($commitOffsets[$topic['topic_name']][$partId] == -1) {
+                    if ($commitOffsets[$topic['topic_name']][$partId] === -1) {
                         continue;
                     }
                     $partitions[$partId]['partition'] = $partId;
@@ -646,13 +646,13 @@ class Process
         $this->state->succRun(\Kafka\Consumer\State::REQUEST_COMMIT_OFFSET);
         foreach ($result as $topic) {
             foreach ($topic['partitions'] as $part) {
-                if ($part['errorCode'] != 0) {
+                if ($part['errorCode'] !== 0) {
                     $this->stateConvert($part['errorCode']);
                     return;  // not call user consumer function
                 }
             }
         }
-        if (ConsumerConfig::getInstance()->getConsumeMode() == ConsumerConfig::CONSUME_AFTER_COMMIT_OFFSET) {
+        if (ConsumerConfig::getInstance()->getConsumeMode() === ConsumerConfig::CONSUME_AFTER_COMMIT_OFFSET) {
             $this->consumeMessage();
         }
     }
@@ -687,7 +687,7 @@ class Process
         }
 
         if (in_array($errorCode, $rejoinCodes, true)) {
-            if ($errorCode == \Kafka\Protocol::UNKNOWN_MEMBER_ID) {
+            if ($errorCode === \Kafka\Protocol::UNKNOWN_MEMBER_ID) {
                 $assign->setMemberId('');
             }
             $assign->clearOffset();
@@ -695,9 +695,9 @@ class Process
             return false;
         }
 
-        if (\Kafka\Protocol::OFFSET_OUT_OF_RANGE == $errorCode) {
+        if (\Kafka\Protocol::OFFSET_OUT_OF_RANGE === $errorCode) {
             $resetOffset = \Kafka\ConsumerConfig::getInstance()->getOffsetReset();
-            if ($resetOffset == 'latest') {
+            if ($resetOffset === 'latest') {
                 $offsets = $assign->getLastOffsets();
             } else {
                 $offsets = $assign->getOffsets();

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -1,102 +1,94 @@
 <?php
 namespace Kafka\Consumer;
 
+use Kafka\Broker;
 use Kafka\ConsumerConfig;
-use Psr\Log\LoggerAwareTrait;
+use Kafka\Exception;
 use Kafka\LoggerTrait;
 use Kafka\Protocol;
-use Kafka\Broker;
-use Kafka\Exception;
+use Kafka\Protocol\Protocol as ProtocolTool;
+use Psr\Log\LoggerAwareTrait;
 
 class Process
 {
     use LoggerAwareTrait;
     use LoggerTrait;
 
+    /**
+     * @var callable|null
+     */
     protected $consumer;
 
+    /**
+     * @var string[][][]
+     */
     protected $messages = [];
+
+    /**
+     * @var State
+     */
+    private $state;
 
     public function __construct(?callable $consumer = null)
     {
         $this->consumer = $consumer;
     }
 
-    /**
-     * start consumer
-     *
-     * @access public
-     * @return void
-     */
-    public function init()
+    public function init(): void
     {
-        // init protocol
-        $config = \Kafka\ConsumerConfig::getInstance();
+        $config = $this->getConfig();
         Protocol::init($config->getBrokerVersion(), $this->logger);
 
-        // init process request
-        $broker = Broker::getInstance();
+        $broker = $this->getBroker();
         $broker->setConfig($config);
-        $broker->setProcess(function ($data, $fd) {
+        $broker->setProcess(function (string $data, int $fd): void {
             $this->processRequest($data, $fd);
         });
 
-        // init state
         $this->state = State::getInstance();
+
         if ($this->logger) {
             $this->state->setLogger($this->logger);
         }
         $this->state->setCallback([
-            \Kafka\Consumer\State::REQUEST_METADATA => function () {
-                return $this->syncMeta();
+            State::REQUEST_METADATA => function (): void {
+                $this->syncMeta();
             },
-            \Kafka\Consumer\State::REQUEST_GETGROUP => function () {
-                return $this->getGroupBrokerId();
+            State::REQUEST_GETGROUP => function (): void {
+                $this->getGroupBrokerId();
             },
-            \Kafka\Consumer\State::REQUEST_JOINGROUP => function () {
-                return $this->joinGroup();
+            State::REQUEST_JOINGROUP => function (): void {
+                $this->joinGroup();
             },
-            \Kafka\Consumer\State::REQUEST_SYNCGROUP => function () {
-                return $this->syncGroup();
+            State::REQUEST_SYNCGROUP => function (): void {
+                $this->syncGroup();
             },
-            \Kafka\Consumer\State::REQUEST_HEARTGROUP => function () {
-                return $this->heartbeat();
+            State::REQUEST_HEARTGROUP => function (): void {
+                $this->heartbeat();
             },
-            \Kafka\Consumer\State::REQUEST_OFFSET => function () {
+            State::REQUEST_OFFSET => function (): array {
                 return $this->offset();
             },
-            \Kafka\Consumer\State::REQUEST_FETCH_OFFSET => function () {
-                return $this->fetchOffset();
+            State::REQUEST_FETCH_OFFSET => function (): void {
+                $this->fetchOffset();
             },
-            \Kafka\Consumer\State::REQUEST_FETCH => function () {
+            State::REQUEST_FETCH => function (): array {
                 return $this->fetch();
             },
-            \Kafka\Consumer\State::REQUEST_COMMIT_OFFSET => function () {
-                return $this->commit();
+            State::REQUEST_COMMIT_OFFSET => function (): void {
+                $this->commit();
             },
         ]);
         $this->state->init();
     }
 
-    /**
-     * start consumer
-     *
-     * @access public
-     * @return void
-     */
-    public function start()
+    public function start(): void
     {
         $this->init();
         $this->state->start();
     }
 
-    /**
-     * stop consumer
-     *
-     * @access public
-     * @return void
-     */
-    public function stop()
+    public function stop(): void
     {
         // TODO: we should remove the consumer from the group here
 
@@ -104,74 +96,84 @@ class Process
     }
 
     /**
-     * process Request
-     *
-     * @access public
-     * @return void
+     * @throws Exception
      */
-    protected function processRequest($data, $fd)
+    protected function processRequest(string $data, int $fd): void
     {
-        $correlationId = \Kafka\Protocol\Protocol::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
+        $correlationId = ProtocolTool::unpack(ProtocolTool::BIT_B32, substr($data, 0, 4));
+
         switch ($correlationId) {
-            case \Kafka\Protocol::METADATA_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::METADATA_REQUEST, substr($data, 4));
-                if (! isset($result['brokers']) || ! isset($result['topics'])) {
+            case Protocol::METADATA_REQUEST:
+                $result = Protocol::decode(Protocol::METADATA_REQUEST, substr($data, 4));
+
+                if (! isset($result['brokers'], $result['topics'])) {
                     $this->error('Get metadata is fail, brokers or topics is null.');
-                    $this->state->failRun(\Kafka\Consumer\State::REQUEST_METADATA);
-                } else {
-                    $broker   = \Kafka\Broker::getInstance();
-                    $isChange = $broker->setData($result['topics'], $result['brokers']);
-                    $this->state->succRun(\Kafka\Consumer\State::REQUEST_METADATA, $isChange);
+                    $this->state->failRun(State::REQUEST_METADATA);
+                    break;
                 }
+
+                /** @var Broker $broker */
+                $broker   = $this->getBroker();
+                $isChange = $broker->setData($result['topics'], $result['brokers']);
+                $this->state->succRun(State::REQUEST_METADATA, $isChange);
+
                 break;
-            case \Kafka\Protocol::GROUP_COORDINATOR_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] === \Kafka\Protocol::NO_ERROR
-                && isset($result['coordinatorId'])) {
-                    \Kafka\Broker::getInstance()->setGroupBrokerId($result['coordinatorId']);
-                    $this->state->succRun(\Kafka\Consumer\State::REQUEST_GETGROUP);
-                } else {
-                    $this->state->failRun(\Kafka\Consumer\State::REQUEST_GETGROUP);
+            case Protocol::GROUP_COORDINATOR_REQUEST:
+                $result = Protocol::decode(Protocol::GROUP_COORDINATOR_REQUEST, substr($data, 4));
+
+                if (! isset($result['errorCode'], $result['coordinatorId']) || $result['errorCode'] !== Protocol::NO_ERROR) {
+                    $this->state->failRun(State::REQUEST_GETGROUP);
+                    break;
                 }
+
+                /** @var Broker $broker */
+                $broker = $this->getBroker();
+                $broker->setGroupBrokerId($result['coordinatorId']);
+
+                $this->state->succRun(State::REQUEST_GETGROUP);
+
                 break;
-            case \Kafka\Protocol::JOIN_GROUP_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] === 0) {
+            case Protocol::JOIN_GROUP_REQUEST:
+                $result = Protocol::decode(Protocol::JOIN_GROUP_REQUEST, substr($data, 4));
+                if (isset($result['errorCode']) && $result['errorCode'] === Protocol::NO_ERROR) {
                     $this->succJoinGroup($result);
-                } else {
-                    $this->failJoinGroup($result['errorCode']);
+                    break;
                 }
+
+                $this->failJoinGroup($result['errorCode']);
                 break;
-            case \Kafka\Protocol::SYNC_GROUP_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] === 0) {
+            case Protocol::SYNC_GROUP_REQUEST:
+                $result = Protocol::decode(Protocol::SYNC_GROUP_REQUEST, substr($data, 4));
+                if (isset($result['errorCode']) && $result['errorCode'] === Protocol::NO_ERROR) {
                     $this->succSyncGroup($result);
-                } else {
-                    $this->failSyncGroup($result['errorCode']);
+                    break;
                 }
+
+                $this->failSyncGroup($result['errorCode']);
                 break;
-            case \Kafka\Protocol::HEART_BEAT_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::HEART_BEAT_REQUEST, substr($data, 4));
-                if (isset($result['errorCode']) && $result['errorCode'] === 0) {
-                    $this->state->succRun(\Kafka\Consumer\State::REQUEST_HEARTGROUP);
-                } else {
-                    $this->failHeartbeat($result['errorCode']);
+            case Protocol::HEART_BEAT_REQUEST:
+                $result = Protocol::decode(Protocol::HEART_BEAT_REQUEST, substr($data, 4));
+                if (isset($result['errorCode']) && $result['errorCode'] === Protocol::NO_ERROR) {
+                    $this->state->succRun(State::REQUEST_HEARTGROUP);
+                    break;
                 }
+
+                $this->failHeartbeat($result['errorCode']);
                 break;
-            case \Kafka\Protocol::OFFSET_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_REQUEST, substr($data, 4));
+            case Protocol::OFFSET_REQUEST:
+                $result = Protocol::decode(Protocol::OFFSET_REQUEST, substr($data, 4));
                 $this->succOffset($result, $fd);
                 break;
-            case \Kafka\Protocol\Protocol::OFFSET_FETCH_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_FETCH_REQUEST, substr($data, 4));
+            case ProtocolTool::OFFSET_FETCH_REQUEST:
+                $result = Protocol::decode(Protocol::OFFSET_FETCH_REQUEST, substr($data, 4));
                 $this->succFetchOffset($result);
                 break;
-            case \Kafka\Protocol\Protocol::FETCH_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::FETCH_REQUEST, substr($data, 4));
+            case ProtocolTool::FETCH_REQUEST:
+                $result = Protocol::decode(Protocol::FETCH_REQUEST, substr($data, 4));
                 $this->succFetch($result, $fd);
                 break;
-            case \Kafka\Protocol\Protocol::OFFSET_COMMIT_REQUEST:
-                $result = \Kafka\Protocol::decode(\Kafka\Protocol::OFFSET_COMMIT_REQUEST, substr($data, 4));
+            case ProtocolTool::OFFSET_COMMIT_REQUEST:
+                $result = Protocol::decode(Protocol::OFFSET_COMMIT_REQUEST, substr($data, 4));
                 $this->succCommit($result);
                 break;
             default:
@@ -179,11 +181,13 @@ class Process
         }
     }
 
-    protected function syncMeta()
+    protected function syncMeta(): void
     {
         $this->debug('Start sync metadata request');
 
-        $brokerList = \Kafka\ConsumerConfig::getInstance()->getMetadataBrokerList();
+        $config = $this->getConfig();
+
+        $brokerList = $config->getMetadataBrokerList();
         $brokerHost = [];
 
         foreach (explode(',', $brokerList) as $key => $val) {
@@ -197,199 +201,229 @@ class Process
         }
 
         shuffle($brokerHost);
-        $broker = \Kafka\Broker::getInstance();
+        $broker = $this->getBroker();
+
         foreach ($brokerHost as $host) {
             $socket = $broker->getMetaConnect($host);
-            if ($socket) {
-                $params = \Kafka\ConsumerConfig::getInstance()->getTopics();
-                $this->debug('Start sync metadata request params:' . json_encode($params));
-                $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::METADATA_REQUEST, $params);
-                $socket->write($requestData);
-                return;
+
+            if ($socket === null) {
+                continue;
             }
+
+            $params = $config->getTopics();
+            $this->debug('Start sync metadata request params:' . json_encode($params));
+            $requestData = Protocol::encode(Protocol::METADATA_REQUEST, $params);
+            $socket->write($requestData);
+
+            return;
         }
 
-        throw new \Kafka\Exception(
-            sprintf(
-                'It was not possible to establish a connection for metadata with the brokers "%s"',
-                $brokerList
-            )
+        throw new Exception(
+            sprintf('It was not possible to establish a connection for metadata with the brokers "%s"', $brokerList)
         );
     }
 
-    protected function getGroupBrokerId()
+    protected function getGroupBrokerId(): void
     {
-        $broker  = \Kafka\Broker::getInstance();
+        $broker  = $this->getBroker();
         $connect = $broker->getRandConnect();
-        if (! $connect) {
+
+        if ($connect === null) {
             return;
         }
-        $params      = [
-            'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),
-        ];
-        $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::GROUP_COORDINATOR_REQUEST, $params);
+
+        $config = $this->getConfig();
+        $params = ['group_id' => $config->getGroupId()];
+
+        $requestData = Protocol::encode(Protocol::GROUP_COORDINATOR_REQUEST, $params);
         $connect->write($requestData);
     }
 
-    protected function joinGroup()
+    protected function joinGroup(): void
     {
-        $broker        = \Kafka\Broker::getInstance();
+        $broker = $this->getBroker();
+
         $groupBrokerId = $broker->getGroupBrokerId();
-        $connect       = $broker->getMetaConnect($groupBrokerId);
-        if (! $connect) {
-            return false;
+        $connect       = $broker->getMetaConnect((string) $groupBrokerId);
+
+        if ($connect === null) {
+            return;
         }
-        $topics      = \Kafka\ConsumerConfig::getInstance()->getTopics();
-        $assign      = Assignment::getInstance();
-        $memberId    = $assign->getMemberId();
-        $params      = [
-            'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),
-            'session_timeout' => \Kafka\ConsumerConfig::getInstance()->getSessionTimeout(),
-            'rebalance_timeout' => \Kafka\ConsumerConfig::getInstance()->getRebalanceTimeout(),
-            'member_id' => ($memberId === null) ? '' : $memberId,
-            'data' => [
+
+        $topics   = $this->getConfig()->getTopics();
+        $assign   = $this->getAssignment();
+        $memberId = $assign->getMemberId();
+
+        $params = [
+            'group_id'          => $this->getConfig()->getGroupId(),
+            'session_timeout'   => $this->getConfig()->getSessionTimeout(),
+            'rebalance_timeout' => $this->getConfig()->getRebalanceTimeout(),
+            'member_id'         => $memberId ?? '',
+            'data'              => [
                 [
                     'protocol_name' => 'range',
-                    'version' => 0,
-                    'subscription' => $topics,
-                    'user_data' => '',
+                    'version'       => 0,
+                    'subscription'  => $topics,
+                    'user_data'     => '',
                 ],
             ],
         ];
-        $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::JOIN_GROUP_REQUEST, $params);
+
+        $requestData = Protocol::encode(Protocol::JOIN_GROUP_REQUEST, $params);
         $connect->write($requestData);
         $this->debug("Join group start, params:" . json_encode($params));
     }
 
-    public function failJoinGroup($errorCode)
+    public function failJoinGroup(int $errorCode): void
     {
-        $assign   = \Kafka\Consumer\Assignment::getInstance();
+        $assign   = $this->getAssignment();
         $memberId = $assign->getMemberId();
-        $error    = sprintf('Join group fail, need rejoin, errorCode %d, memberId: %s', $errorCode, $memberId);
-        $this->error($error);
+
+        $this->error(sprintf('Join group fail, need rejoin, errorCode %d, memberId: %s', $errorCode, $memberId));
         $this->stateConvert($errorCode);
     }
 
-    public function succJoinGroup($result)
+    /**
+     * @param mixed[] $result
+     */
+    public function succJoinGroup(array $result): void
     {
-        $this->state->succRun(\Kafka\Consumer\State::REQUEST_JOINGROUP);
-        $assign = \Kafka\Consumer\Assignment::getInstance();
+        $this->state->succRun(State::REQUEST_JOINGROUP);
+        $assign = $this->getAssignment();
         $assign->setMemberId($result['memberId']);
         $assign->setGenerationId($result['generationId']);
+
         if ($result['leaderId'] === $result['memberId']) { // leader assign partition
-            $assigns = $assign->assign($result['members']);
+            $assign->assign($result['members']);
         }
-        $msg = sprintf('Join group sucess, params: %s', json_encode($result));
-        $this->debug($msg);
+
+        $this->debug(sprintf('Join group sucess, params: %s', json_encode($result)));
     }
 
-    public function syncGroup()
+    public function syncGroup(): void
     {
-        $broker        = \Kafka\Broker::getInstance();
+        $broker        = $this->getBroker();
         $groupBrokerId = $broker->getGroupBrokerId();
-        $connect       = $broker->getMetaConnect($groupBrokerId);
-        if (! $connect) {
+        $connect       = $broker->getMetaConnect((string) $groupBrokerId);
+
+        if ($connect === null) {
             return;
         }
-        $topics       = \Kafka\ConsumerConfig::getInstance()->getTopics();
-        $assign       = \Kafka\Consumer\Assignment::getInstance();
+
+        $assign       = $this->getAssignment();
         $memberId     = $assign->getMemberId();
         $generationId = $assign->getGenerationId();
-        $params       = [
-            'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),
-            'generation_id' => $generationId,
-            'member_id' => $memberId,
-            'data' => $assign->getAssignments(),
+
+        $params = [
+            'group_id'      => $this->getConfig()->getGroupId(),
+            'generation_id' => $generationId ?? null,
+            'member_id'     => $memberId,
+            'data'          => $assign->getAssignments(),
         ];
-        $requestData  = \Kafka\Protocol::encode(\Kafka\Protocol::SYNC_GROUP_REQUEST, $params);
+
+        $requestData = Protocol::encode(Protocol::SYNC_GROUP_REQUEST, $params);
         $this->debug("Sync group start, params:" . json_encode($params));
+
         $connect->write($requestData);
     }
 
-    public function failSyncGroup($errorCode)
+    public function failSyncGroup(int $errorCode): void
     {
-        $error = sprintf('Sync group fail, need rejoin, errorCode %d', $errorCode);
-        $this->error($error);
+        $this->error(sprintf('Sync group fail, need rejoin, errorCode %d', $errorCode));
         $this->stateConvert($errorCode);
     }
 
-    public function succSyncGroup($result)
+    /**
+     * @param mixed[][] $result
+     */
+    public function succSyncGroup(array $result): void
     {
-        $msg = sprintf('Sync group sucess, params: %s', json_encode($result));
-        $this->debug($msg);
-        $this->state->succRun(\Kafka\Consumer\State::REQUEST_SYNCGROUP);
+        $this->debug(sprintf('Sync group sucess, params: %s', json_encode($result)));
+        $this->state->succRun(State::REQUEST_SYNCGROUP);
 
-        $topics         = \Kafka\Broker::getInstance()->getTopics();
+        $topics = $this->getBroker()->getTopics();
+
         $brokerToTopics = [];
+
         foreach ($result['partitionAssignments'] as $topic) {
             foreach ($topic['partitions'] as $partId) {
                 $brokerId = $topics[$topic['topicName']][$partId];
-                if (! isset($brokerToTopics[$brokerId])) {
-                    $brokerToTopics[$brokerId] = [];
-                }
 
-                $topicInfo = [];
-                if (isset($brokerToTopics[$brokerId][$topic['topicName']])) {
-                    $topicInfo = $brokerToTopics[$brokerId][$topic['topicName']];
-                }
+                $brokerToTopics[$brokerId] = $brokerToTopics[$brokerId] ?? [];
+
+                $topicInfo = $brokerToTopics[$brokerId][$topic['topicName']] ?? [];
+
                 $topicInfo['topic_name'] = $topic['topicName'];
-                if (! isset($topicInfo['partitions'])) {
-                    $topicInfo['partitions'] = [];
-                }
-                $topicInfo['partitions'][]                      = $partId;
+
+                $topicInfo['partitions']   = $topicInfo['partitions'] ?? [];
+                $topicInfo['partitions'][] = $partId;
+
                 $brokerToTopics[$brokerId][$topic['topicName']] = $topicInfo;
             }
         }
-        $assign = \Kafka\Consumer\Assignment::getInstance();
+
+        $assign = $this->getAssignment();
         $assign->setTopics($brokerToTopics);
     }
 
-    protected function heartbeat()
+    protected function heartbeat(): void
     {
-        $broker        = \Kafka\Broker::getInstance();
+        $broker        = $this->getBroker();
         $groupBrokerId = $broker->getGroupBrokerId();
-        $connect       = $broker->getMetaConnect($groupBrokerId);
-        if (! $connect) {
+        $connect       = $broker->getMetaConnect((string) $groupBrokerId);
+
+        if ($connect === null) {
             return;
         }
-        $assign   = \Kafka\Consumer\Assignment::getInstance();
+
+        $assign   = $this->getAssignment();
         $memberId = $assign->getMemberId();
-        if (! $memberId) {
+
+        if (trim($memberId) === '') {
             return;
         }
+
         $generationId = $assign->getGenerationId();
-        $params       = [
-            'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),
+
+        $params = [
+            'group_id'      => $this->getConfig()->getGroupId(),
             'generation_id' => $generationId,
-            'member_id' => $memberId,
+            'member_id'     => $memberId,
         ];
-        $requestData  = \Kafka\Protocol::encode(\Kafka\Protocol::HEART_BEAT_REQUEST, $params);
-        //$this->debug("Heartbeat group start, params:" . json_encode($params));
+
+        $requestData = Protocol::encode(Protocol::HEART_BEAT_REQUEST, $params);
         $connect->write($requestData);
     }
 
-    public function failHeartbeat($errorCode)
+    public function failHeartbeat(int $errorCode): void
     {
         $this->error('Heartbeat error, errorCode:' . $errorCode);
         $this->stateConvert($errorCode);
     }
 
-    protected function offset()
+    /**
+     * @return int[]
+     */
+    protected function offset(): array
     {
         $context = [];
-        $broker  = \Kafka\Broker::getInstance();
-        $topics  = \Kafka\Consumer\Assignment::getInstance()->getTopics();
+        $broker  = $this->getBroker();
+        $topics  = $this->getAssignment()->getTopics();
+
         foreach ($topics as $brokerId => $topicList) {
             $connect = $broker->getMetaConnect($brokerId);
-            if (! $connect) {
-                return;
+
+            if ($connect === null) {
+                return [];
             }
+
             $data = [];
             foreach ($topicList as $topic) {
                 $item = [
                     'topic_name' => $topic['topic_name'],
                     'partitions' => [],
                 ];
+
                 foreach ($topic['partitions'] as $partId) {
                     $item['partitions'][] = [
                         'partition_id' => $partId,
@@ -399,13 +433,15 @@ class Process
                     $data[]               = $item;
                 }
             }
+
             $params = [
                 'replica_id' => -1,
-                'data' => $data,
+                'data'       => $data,
             ];
-            $stream = $connect->getSocket();
-            //$this->debug("Get current offset start, params:" . json_encode($params));
-            $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_REQUEST, $params);
+
+            $stream      = $connect->getSocket();
+            $requestData = Protocol::encode(Protocol::OFFSET_REQUEST, $params);
+
             $connect->write($requestData);
             $context[] = (int) $stream;
         }
@@ -413,16 +449,17 @@ class Process
         return $context;
     }
 
-    public function succOffset($result, $fd)
+    /**
+     * @param mixed[][] $result
+     */
+    public function succOffset(array $result, int $fd): void
     {
-        $msg = sprintf('Get current offset sucess, result: %s', json_encode($result));
-        //$this->debug($msg);
+        $offsets     = $this->getAssignment()->getOffsets();
+        $lastOffsets = $this->getAssignment()->getLastOffsets();
 
-        $offsets     = \Kafka\Consumer\Assignment::getInstance()->getOffsets();
-        $lastOffsets = \Kafka\Consumer\Assignment::getInstance()->getLastOffsets();
         foreach ($result as $topic) {
             foreach ($topic['partitions'] as $part) {
-                if ($part['errorCode'] !== 0) {
+                if ($part['errorCode'] !== Protocol::NO_ERROR) {
                     $this->stateConvert($part['errorCode']);
                     break 2;
                 }
@@ -431,51 +468,62 @@ class Process
                 $lastOffsets[$topic['topicName']][$part['partition']] = $part['offsets'][0];
             }
         }
-        \Kafka\Consumer\Assignment::getInstance()->setOffsets($offsets);
-        \Kafka\Consumer\Assignment::getInstance()->setLastOffsets($lastOffsets);
-        $this->state->succRun(\Kafka\Consumer\State::REQUEST_OFFSET, $fd);
+
+        $this->getAssignment()->setOffsets($offsets);
+        $this->getAssignment()->setLastOffsets($lastOffsets);
+        $this->state->succRun(State::REQUEST_OFFSET, $fd);
     }
 
-    protected function fetchOffset()
+    protected function fetchOffset(): void
     {
-        $broker        = \Kafka\Broker::getInstance();
+        $broker        = $this->getBroker();
         $groupBrokerId = $broker->getGroupBrokerId();
-        $connect       = $broker->getMetaConnect($groupBrokerId);
-        if (! $connect) {
+        $connect       = $broker->getMetaConnect((string) $groupBrokerId);
+
+        if ($connect === null) {
             return;
         }
 
-        $topics = \Kafka\Consumer\Assignment::getInstance()->getTopics();
+        $topics = $this->getAssignment()->getTopics();
         $data   = [];
+
         foreach ($topics as $brokerId => $topicList) {
             foreach ($topicList as $topic) {
                 $partitions = [];
+
                 if (isset($data[$topic['topic_name']]['partitions'])) {
                     $partitions = $data[$topic['topic_name']]['partitions'];
                 }
+
                 foreach ($topic['partitions'] as $partId) {
                     $partitions[] = $partId;
                 }
+
                 $data[$topic['topic_name']]['partitions'] = $partitions;
                 $data[$topic['topic_name']]['topic_name'] = $topic['topic_name'];
             }
         }
+
         $params = [
-            'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),
-            'data' => $data,
+            'group_id' => $this->getConfig()->getGroupId(),
+            'data'     => $data,
         ];
-        //$this->debug("Get current fetch offset start, params:" . json_encode($params));
-        $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_FETCH_REQUEST, $params);
+
+        $requestData = Protocol::encode(Protocol::OFFSET_FETCH_REQUEST, $params);
         $connect->write($requestData);
     }
 
-    public function succFetchOffset($result)
+    /**
+     * @param mixed[] $result
+     */
+    public function succFetchOffset(array $result): void
     {
         $msg = sprintf('Get current fetch offset sucess, result: %s', json_encode($result));
         $this->debug($msg);
 
-        $assign  = \Kafka\Consumer\Assignment::getInstance();
+        $assign  = $this->getAssignment();
         $offsets = $assign->getFetchOffsets();
+
         foreach ($result as $topic) {
             foreach ($topic['partitions'] as $part) {
                 if ($part['errorCode'] !== 0) {
@@ -486,12 +534,15 @@ class Process
                 $offsets[$topic['topicName']][$part['partition']] = $part['offset'];
             }
         }
+
         $assign->setFetchOffsets($offsets);
 
         $consumerOffsets = $assign->getConsumerOffsets();
         $lastOffsets     = $assign->getLastOffsets();
+
         if (empty($consumerOffsets)) {
             $consumerOffsets = $assign->getFetchOffsets();
+
             foreach ($consumerOffsets as $topic => $value) {
                 foreach ($value as $partId => $offset) {
                     if (isset($lastOffsets[$topic][$partId]) && $lastOffsets[$topic][$partId] > $offset) {
@@ -499,73 +550,93 @@ class Process
                     }
                 }
             }
+
             $assign->setConsumerOffsets($consumerOffsets);
             $assign->setCommitOffsets($assign->getFetchOffsets());
         }
-        $this->state->succRun(\Kafka\Consumer\State::REQUEST_FETCH_OFFSET);
+
+        $this->state->succRun(State::REQUEST_FETCH_OFFSET);
     }
 
-    protected function fetch()
+    /**
+     * @return int[]
+     */
+    protected function fetch(): array
     {
         $this->messages  = [];
         $context         = [];
-        $broker          = \Kafka\Broker::getInstance();
-        $topics          = \Kafka\Consumer\Assignment::getInstance()->getTopics();
-        $consumerOffsets = \Kafka\Consumer\Assignment::getInstance()->getConsumerOffsets();
+        $broker          = $this->getBroker();
+        $topics          = $this->getAssignment()->getTopics();
+        $consumerOffsets = $this->getAssignment()->getConsumerOffsets();
+
         foreach ($topics as $brokerId => $topicList) {
             $connect = $broker->getDataConnect($brokerId);
-            if (! $connect) {
-                return;
+
+            if ($connect === null) {
+                return [];
             }
 
             $data = [];
+
             foreach ($topicList as $topic) {
                 $item = [
                     'topic_name' => $topic['topic_name'],
                     'partitions' => [],
                 ];
+
                 foreach ($topic['partitions'] as $partId) {
                     $item['partitions'][] = [
                         'partition_id' => $partId,
                         'offset' => isset($consumerOffsets[$topic['topic_name']][$partId]) ? $consumerOffsets[$topic['topic_name']][$partId] : 0,
-                        'max_bytes' => \Kafka\ConsumerConfig::getInstance()->getMaxBytes(),
+                        'max_bytes' => $this->getConfig()->getMaxBytes(),
                     ];
                 }
+
                 $data[] = $item;
             }
+
             $params = [
-                'max_wait_time' => \Kafka\ConsumerConfig::getInstance()->getMaxWaitTime(),
+                'max_wait_time' => $this->getConfig()->getMaxWaitTime(),
                 'replica_id' => -1,
                 'min_bytes' => '1000',
                 'data' => $data,
             ];
+
             $this->debug("Fetch message start, params:" . json_encode($params));
-            $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::FETCH_REQUEST, $params);
+            $requestData = Protocol::encode(Protocol::FETCH_REQUEST, $params);
             $connect->write($requestData);
             $context[] = (int) $connect->getSocket();
         }
+
         return $context;
     }
 
-    public function succFetch($result, $fd)
+    /**
+     * @param mixed[][][] $result
+     */
+    public function succFetch(array $result, int $fd): void
     {
-        $assign = \Kafka\Consumer\Assignment::getInstance();
+        $assign = $this->getAssignment();
         $this->debug('Fetch success, result:' . json_encode($result));
+
         foreach ($result['topics'] as $topic) {
             foreach ($topic['partitions'] as $part) {
                 $context = [
                     $topic['topicName'],
                     $part['partition'],
                 ];
+
                 if ($part['errorCode'] !== 0) {
                     $this->stateConvert($part['errorCode'], $context);
                     continue;
                 }
 
                 $offset = $assign->getConsumerOffset($topic['topicName'], $part['partition']);
-                if ($offset === false) {
+
+                if ($offset === null) {
                     return; // current is rejoin....
                 }
+
                 foreach ($part['messages'] as $message) {
                     $this->messages[$topic['topicName']][$part['partition']][] = $message;
 
@@ -577,10 +648,11 @@ class Process
                 $assign->setCommitOffset($topic['topicName'], $part['partition'], $offset);
             }
         }
-        $this->state->succRun(\Kafka\Consumer\State::REQUEST_FETCH, $fd);
+
+        $this->state->succRun(State::REQUEST_FETCH, $fd);
     }
 
-    protected function consumeMessage()
+    protected function consumeMessage(): void
     {
         foreach ($this->messages as $topic => $value) {
             foreach ($value as $partition => $messages) {
@@ -595,60 +667,69 @@ class Process
         $this->messages = [];
     }
 
-    protected function commit()
+    protected function commit(): void
     {
-        $config = ConsumerConfig::getInstance();
+        $config = $this->getConfig();
+
         if ($config->getConsumeMode() === ConsumerConfig::CONSUME_BEFORE_COMMIT_OFFSET) {
             $this->consumeMessage();
         }
 
-        $broker        = \Kafka\Broker::getInstance();
+        $broker        = $this->getBroker();
         $groupBrokerId = $broker->getGroupBrokerId();
-        $connect       = $broker->getMetaConnect($groupBrokerId);
-        if (! $connect) {
+        $connect       = $broker->getMetaConnect((string) $groupBrokerId);
+
+        if ($connect === null) {
             return;
         }
 
-        $commitOffsets = \Kafka\Consumer\Assignment::getInstance()->getCommitOffsets();
-        $topics        = \Kafka\Consumer\Assignment::getInstance()->getTopics();
-        \Kafka\Consumer\Assignment::getInstance()->setPrecommitOffsets($commitOffsets);
+        $commitOffsets = $this->getAssignment()->getCommitOffsets();
+        $topics        = $this->getAssignment()->getTopics();
+        $this->getAssignment()->setPreCommitOffsets($commitOffsets);
         $data = [];
+
         foreach ($topics as $brokerId => $topicList) {
             foreach ($topicList as $topic) {
                 $partitions = [];
+
                 if (isset($data[$topic['topic_name']]['partitions'])) {
                     $partitions = $data[$topic['topic_name']]['partitions'];
                 }
+
                 foreach ($topic['partitions'] as $partId) {
                     if ($commitOffsets[$topic['topic_name']][$partId] === -1) {
                         continue;
                     }
+
                     $partitions[$partId]['partition'] = $partId;
                     $partitions[$partId]['offset']    = $commitOffsets[$topic['topic_name']][$partId];
                 }
+
                 $data[$topic['topic_name']]['partitions'] = $partitions;
                 $data[$topic['topic_name']]['topic_name'] = $topic['topic_name'];
             }
         }
+
         $params = [
-            'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),
-            'generation_id' => \Kafka\Consumer\Assignment::getInstance()->getGenerationId(),
-            'member_id' => \Kafka\Consumer\Assignment::getInstance()->getMemberId(),
+            'group_id' => $this->getConfig()->getGroupId(),
+            'generation_id' => $this->getAssignment()->getGenerationId(),
+            'member_id' => $this->getAssignment()->getMemberId(),
             'data' => $data,
         ];
+
         $this->debug("Commit current fetch offset start, params:" . json_encode($params));
-        $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::OFFSET_COMMIT_REQUEST, $params);
+        $requestData = Protocol::encode(Protocol::OFFSET_COMMIT_REQUEST, $params);
         $connect->write($requestData);
     }
 
     /**
-     * @var State
+     * @param mixed[][] $result
      */
-    public $state;
-    public function succCommit($result)
+    public function succCommit(array $result): void
     {
         $this->debug('Commit success, result:' . json_encode($result));
-        $this->state->succRun(\Kafka\Consumer\State::REQUEST_COMMIT_OFFSET);
+        $this->state->succRun(State::REQUEST_COMMIT_OFFSET);
+
         foreach ($result as $topic) {
             foreach ($topic['partitions'] as $part) {
                 if ($part['errorCode'] !== 0) {
@@ -657,34 +738,40 @@ class Process
                 }
             }
         }
-        if (ConsumerConfig::getInstance()->getConsumeMode() === ConsumerConfig::CONSUME_AFTER_COMMIT_OFFSET) {
+
+        if ($this->getConfig()->getConsumeMode() === ConsumerConfig::CONSUME_AFTER_COMMIT_OFFSET) {
             $this->consumeMessage();
         }
     }
 
-    protected function stateConvert($errorCode, $context = null)
+    /**
+     * @param string[] $context
+     */
+    protected function stateConvert(int $errorCode, ?array $context = null): bool
     {
-        $retry = false;
-        $this->error(\Kafka\Protocol::getError($errorCode));
+        $this->error(Protocol::getError($errorCode));
+
         $recoverCodes = [
-            \Kafka\Protocol::UNKNOWN_TOPIC_OR_PARTITION,
-            \Kafka\Protocol::NOT_LEADER_FOR_PARTITION,
-            \Kafka\Protocol::BROKER_NOT_AVAILABLE,
-            \Kafka\Protocol::GROUP_LOAD_IN_PROGRESS,
-            \Kafka\Protocol::GROUP_COORDINATOR_NOT_AVAILABLE,
-            \Kafka\Protocol::NOT_COORDINATOR_FOR_GROUP,
-            \Kafka\Protocol::INVALID_TOPIC,
-            \Kafka\Protocol::INCONSISTENT_GROUP_PROTOCOL,
-            \Kafka\Protocol::INVALID_GROUP_ID,
-        ];
-        $rejoinCodes  = [
-            \Kafka\Protocol::ILLEGAL_GENERATION,
-            \Kafka\Protocol::INVALID_SESSION_TIMEOUT,
-            \Kafka\Protocol::REBALANCE_IN_PROGRESS,
-            \Kafka\Protocol::UNKNOWN_MEMBER_ID,
+            Protocol::UNKNOWN_TOPIC_OR_PARTITION,
+            Protocol::NOT_LEADER_FOR_PARTITION,
+            Protocol::BROKER_NOT_AVAILABLE,
+            Protocol::GROUP_LOAD_IN_PROGRESS,
+            Protocol::GROUP_COORDINATOR_NOT_AVAILABLE,
+            Protocol::NOT_COORDINATOR_FOR_GROUP,
+            Protocol::INVALID_TOPIC,
+            Protocol::INCONSISTENT_GROUP_PROTOCOL,
+            Protocol::INVALID_GROUP_ID,
         ];
 
-        $assign = \Kafka\Consumer\Assignment::getInstance();
+        $rejoinCodes = [
+            Protocol::ILLEGAL_GENERATION,
+            Protocol::INVALID_SESSION_TIMEOUT,
+            Protocol::REBALANCE_IN_PROGRESS,
+            Protocol::UNKNOWN_MEMBER_ID,
+        ];
+
+        $assign = $this->getAssignment();
+
         if (in_array($errorCode, $recoverCodes, true)) {
             $this->state->recover();
             $assign->clearOffset();
@@ -692,26 +779,41 @@ class Process
         }
 
         if (in_array($errorCode, $rejoinCodes, true)) {
-            if ($errorCode === \Kafka\Protocol::UNKNOWN_MEMBER_ID) {
+            if ($errorCode === Protocol::UNKNOWN_MEMBER_ID) {
                 $assign->setMemberId('');
             }
+
             $assign->clearOffset();
             $this->state->rejoin();
             return false;
         }
 
-        if ($errorCode === \Kafka\Protocol::OFFSET_OUT_OF_RANGE) {
-            $resetOffset = \Kafka\ConsumerConfig::getInstance()->getOffsetReset();
-            if ($resetOffset === 'latest') {
-                $offsets = $assign->getLastOffsets();
-            } else {
-                $offsets = $assign->getOffsets();
-            }
-            list($topic, $partId) = $context;
+        if ($errorCode === Protocol::OFFSET_OUT_OF_RANGE) {
+            $resetOffset = $this->getConfig()->getOffsetReset();
+            $offsets     = $resetOffset === 'latest' ? $assign->getLastOffsets() : $assign->getOffsets();
+
+            [$topic, $partId] = $context;
+
             if (isset($offsets[$topic][$partId])) {
                 $assign->setConsumerOffset($topic, $partId, $offsets[$topic][$partId]);
             }
         }
+
         return true;
+    }
+
+    private function getBroker(): Broker
+    {
+        return Broker::getInstance();
+    }
+
+    private function getConfig(): ConsumerConfig
+    {
+        return ConsumerConfig::getInstance();
+    }
+
+    private function getAssignment(): Assignment
+    {
+        return Assignment::getInstance();
     }
 }

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -8,11 +8,11 @@ class Process
     use \Psr\Log\LoggerAwareTrait;
     use \Kafka\LoggerTrait;
 
-    protected $consumer = null;
+    protected $consumer;
 
     protected $messages = [];
 
-    public function __construct(callable $consumer = null)
+    public function __construct(?callable $consumer = null)
     {
         $this->consumer = $consumer;
     }

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Consumer;
 
 use Kafka\Broker;
@@ -411,7 +413,7 @@ class Process
         $topics  = $this->getAssignment()->getTopics();
 
         foreach ($topics as $brokerId => $topicList) {
-            $connect = $broker->getMetaConnect($brokerId);
+            $connect = $broker->getMetaConnect((string) $brokerId);
 
             if ($connect === null) {
                 return [];
@@ -570,7 +572,7 @@ class Process
         $consumerOffsets = $this->getAssignment()->getConsumerOffsets();
 
         foreach ($topics as $brokerId => $topicList) {
-            $connect = $broker->getDataConnect($brokerId);
+            $connect = $broker->getDataConnect((string) $brokerId);
 
             if ($connect === null) {
                 return [];
@@ -795,7 +797,7 @@ class Process
             [$topic, $partId] = $context;
 
             if (isset($offsets[$topic][$partId])) {
-                $assign->setConsumerOffset($topic, $partId, $offsets[$topic][$partId]);
+                $assign->setConsumerOffset($topic, (int) $partId, $offsets[$topic][$partId]);
             }
         }
 

--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -2,11 +2,16 @@
 namespace Kafka\Consumer;
 
 use Kafka\ConsumerConfig;
+use Psr\Log\LoggerAwareTrait;
+use Kafka\LoggerTrait;
+use Kafka\Protocol;
+use Kafka\Broker;
+use Kafka\Exception;
 
 class Process
 {
-    use \Psr\Log\LoggerAwareTrait;
-    use \Kafka\LoggerTrait;
+    use LoggerAwareTrait;
+    use LoggerTrait;
 
     protected $consumer;
 
@@ -27,17 +32,17 @@ class Process
     {
         // init protocol
         $config = \Kafka\ConsumerConfig::getInstance();
-        \Kafka\Protocol::init($config->getBrokerVersion(), $this->logger);
+        Protocol::init($config->getBrokerVersion(), $this->logger);
 
         // init process request
-        $broker = \Kafka\Broker::getInstance();
+        $broker = Broker::getInstance();
         $broker->setConfig($config);
         $broker->setProcess(function ($data, $fd) {
             $this->processRequest($data, $fd);
         });
 
         // init state
-        $this->state = \Kafka\Consumer\State::getInstance();
+        $this->state = State::getInstance();
         if ($this->logger) {
             $this->state->setLogger($this->logger);
         }
@@ -188,7 +193,7 @@ class Process
         }
 
         if (count($brokerHost) === 0) {
-            throw new \Kafka\Exception('No valid broker configured');
+            throw new Exception('No valid broker configured');
         }
 
         shuffle($brokerHost);
@@ -235,7 +240,7 @@ class Process
             return false;
         }
         $topics      = \Kafka\ConsumerConfig::getInstance()->getTopics();
-        $assign      = \Kafka\Consumer\Assignment::getInstance();
+        $assign      = Assignment::getInstance();
         $memberId    = $assign->getMemberId();
         $params      = [
             'group_id' => \Kafka\ConsumerConfig::getInstance()->getGroupId(),

--- a/src/Consumer/State.php
+++ b/src/Consumer/State.php
@@ -187,7 +187,7 @@ class State
     public function rejoin()
     {
         $joinGroupStatus = $this->callStatus[self::REQUEST_JOINGROUP]['status'];
-        if (($joinGroupStatus & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+        if (($joinGroupStatus & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
             return;
         }
 
@@ -228,91 +228,91 @@ class State
         $status = $this->callStatus[$key]['status'];
         switch ($key) {
             case self::REQUEST_METADATA:
-                if ($status & self::STATUS_PROCESS == self::STATUS_PROCESS) {
+                if ($status & self::STATUS_PROCESS === self::STATUS_PROCESS) {
                     return false;
                 }
-                if (($status & self::STATUS_LOOP) == self::STATUS_LOOP) {
+                if (($status & self::STATUS_LOOP) === self::STATUS_LOOP) {
                     return true;
                 }
                 return false;
             case self::REQUEST_GETGROUP:
-                if (($status & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+                if (($status & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
                     return false;
                 }
                 $metaStatus = $this->callStatus[self::REQUEST_METADATA]['status'];
-                if (($metaStatus & self::STATUS_FINISH) != self::STATUS_FINISH) {
+                if (($metaStatus & self::STATUS_FINISH) !== self::STATUS_FINISH) {
                     return false;
                 }
-                if (($status & self::STATUS_START) == self::STATUS_START) {
+                if (($status & self::STATUS_START) === self::STATUS_START) {
                     return true;
                 }
                 return false;
             case self::REQUEST_JOINGROUP:
-                if (($status & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+                if (($status & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
                     return false;
                 }
                 $groupStatus = $this->callStatus[self::REQUEST_GETGROUP]['status'];
-                if (($groupStatus & self::STATUS_FINISH) != self::STATUS_FINISH) {
+                if (($groupStatus & self::STATUS_FINISH) !== self::STATUS_FINISH) {
                     return false;
                 }
-                if (($status & self::STATUS_START) == self::STATUS_START) {
+                if (($status & self::STATUS_START) === self::STATUS_START) {
                     return true;
                 }
                 return false;
             case self::REQUEST_SYNCGROUP:
-                if (($status & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+                if (($status & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
                     return false;
                 }
                 $joinStatus = $this->callStatus[self::REQUEST_JOINGROUP]['status'];
-                if (($joinStatus & self::STATUS_FINISH) != self::STATUS_FINISH) {
+                if (($joinStatus & self::STATUS_FINISH) !== self::STATUS_FINISH) {
                     return false;
                 }
-                if (($status & self::STATUS_START) == self::STATUS_START) {
+                if (($status & self::STATUS_START) === self::STATUS_START) {
                     return true;
                 }
                 return false;
             case self::REQUEST_HEARTGROUP:
             case self::REQUEST_OFFSET:
-                if (($status & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+                if (($status & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
                     return false;
                 }
                 $syncStatus = $this->callStatus[self::REQUEST_SYNCGROUP]['status'];
-                if (($syncStatus & self::STATUS_FINISH) != self::STATUS_FINISH) {
+                if (($syncStatus & self::STATUS_FINISH) !== self::STATUS_FINISH) {
                     return false;
                 }
-                if (($status & self::STATUS_LOOP) == self::STATUS_LOOP) {
+                if (($status & self::STATUS_LOOP) === self::STATUS_LOOP) {
                     return true;
                 }
                 return false;
             case self::REQUEST_FETCH_OFFSET:
-                if (($status & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+                if (($status & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
                     return false;
                 }
                 $syncStatus = $this->callStatus[self::REQUEST_SYNCGROUP]['status'];
-                if (($syncStatus & self::STATUS_FINISH) != self::STATUS_FINISH) {
+                if (($syncStatus & self::STATUS_FINISH) !== self::STATUS_FINISH) {
                     return false;
                 }
                 $offsetStatus = $this->callStatus[self::REQUEST_OFFSET]['status'];
-                if (($offsetStatus & self::STATUS_FINISH) != self::STATUS_FINISH) {
+                if (($offsetStatus & self::STATUS_FINISH) !== self::STATUS_FINISH) {
                     return false;
                 }
-                if (($status & self::STATUS_LOOP) == self::STATUS_LOOP) {
+                if (($status & self::STATUS_LOOP) === self::STATUS_LOOP) {
                     return true;
                 }
                 return false;
             case self::REQUEST_FETCH:
-                if (($status & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+                if (($status & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
                     return false;
                 }
                 $fetchOffsetStatus = $this->callStatus[self::REQUEST_FETCH_OFFSET]['status'];
-                if (($fetchOffsetStatus & self::STATUS_FINISH) != self::STATUS_FINISH) {
+                if (($fetchOffsetStatus & self::STATUS_FINISH) !== self::STATUS_FINISH) {
                     return false;
                 }
                 $commitOffsetStatus = $this->callStatus[self::REQUEST_COMMIT_OFFSET]['status'];
-                if (($commitOffsetStatus & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
+                if (($commitOffsetStatus & self::STATUS_PROCESS) === self::STATUS_PROCESS) {
                     return false;
                 }
-                if (($status & self::STATUS_LOOP) == self::STATUS_LOOP) {
+                if (($status & self::STATUS_LOOP) === self::STATUS_LOOP) {
                     return true;
                 }
                 return false;

--- a/src/Consumer/State.php
+++ b/src/Consumer/State.php
@@ -2,8 +2,8 @@
 namespace Kafka\Consumer;
 
 use Amp\Loop;
-use Kafka\SingletonTrait;
 use Kafka\ConsumerConfig;
+use Kafka\SingletonTrait;
 
 class State
 {

--- a/src/Consumer/State.php
+++ b/src/Consumer/State.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Consumer;
 
 use Amp\Loop;
@@ -85,7 +87,7 @@ class State
             $interval = $option['interval'] ?? 200;
 
             Loop::repeat(
-                $interval,
+                (int) $interval,
                 function (string $watcherId) use ($request, $option): void {
                     if ($this->checkRun($request) && $option['func'] !== null) {
                         $this->processing($request, $option['func']());

--- a/src/Consumer/State.php
+++ b/src/Consumer/State.php
@@ -114,7 +114,7 @@ class State
 
     private function removeWatchers(): void
     {
-        foreach (array_keys($this->requests) as $request) {
+        foreach (\array_keys($this->requests) as $request) {
             if (! isset($this->requests[$request]['watcher'])) {
                 return;
             }
@@ -355,7 +355,7 @@ class State
         }
 
         // set process start time
-        $this->callStatus[$key]['time'] = microtime(true);
+        $this->callStatus[$key]['time'] = \microtime(true);
         switch ($key) {
             case self::REQUEST_METADATA:
             case self::REQUEST_GETGROUP:

--- a/src/Consumer/State.php
+++ b/src/Consumer/State.php
@@ -2,10 +2,12 @@
 namespace Kafka\Consumer;
 
 use Amp\Loop;
+use Kafka\SingletonTrait;
+use Kafka\ConsumerConfig;
 
 class State
 {
-    use \Kafka\SingletonTrait;
+    use SingletonTrait;
 
     public const REQUEST_METADATA      = 1;
     public const REQUEST_GETGROUP      = 2;
@@ -57,7 +59,7 @@ class State
         // instances clear
 
         // init requests
-        $config = \Kafka\ConsumerConfig::getInstance();
+        $config = ConsumerConfig::getInstance();
         foreach ($this->requests as $request => $option) {
             switch ($request) {
                 case self::REQUEST_METADATA:

--- a/src/ConsumerConfig.php
+++ b/src/ConsumerConfig.php
@@ -17,10 +17,16 @@ class ConsumerConfig extends Config
     public const CONSUME_AFTER_COMMIT_OFFSET  = 1;
     public const CONSUME_BEFORE_COMMIT_OFFSET = 2;
 
+    /**
+     * @var mixed[]
+     */
     protected $runtimeOptions = [
         'consume_mode' => self::CONSUME_AFTER_COMMIT_OFFSET,
     ];
 
+    /**
+     * @var mixed[]
+     */
     protected static $defaults = [
         'groupId'          => '',
         'sessionTimeout'   => 30000,
@@ -31,6 +37,9 @@ class ConsumerConfig extends Config
         'maxWaitTime'      => 100,
     ];
 
+    /**
+     * @throws \Kafka\Exception\Config
+     */
     public function getGroupId(): string
     {
         $groupId = trim($this->ietGroupId());
@@ -42,6 +51,9 @@ class ConsumerConfig extends Config
         return $groupId;
     }
 
+    /**
+     * @throws \Kafka\Exception\Config
+     */
     public function setGroupId(string $groupId): void
     {
         $groupId = trim($groupId);
@@ -53,6 +65,11 @@ class ConsumerConfig extends Config
         static::$options['groupId'] = $groupId;
     }
 
+    /**
+     * @param int|string|float $sessionTimeout
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function setSessionTimeout($sessionTimeout): void
     {
         if (! is_numeric($sessionTimeout) || $sessionTimeout < 1 || $sessionTimeout > 3600000) {
@@ -62,6 +79,11 @@ class ConsumerConfig extends Config
         static::$options['sessionTimeout'] = $sessionTimeout;
     }
 
+    /**
+     * @param int|string|float $rebalanceTimeout
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function setRebalanceTimeout($rebalanceTimeout): void
     {
         if (! is_numeric($rebalanceTimeout) || $rebalanceTimeout < 1 || $rebalanceTimeout > 3600000) {
@@ -71,7 +93,10 @@ class ConsumerConfig extends Config
         static::$options['rebalanceTimeout'] = $rebalanceTimeout;
     }
 
-    public function setOffsetReset($offsetReset): void
+    /**
+     * @throws \Kafka\Exception\Config
+     */
+    public function setOffsetReset(string $offsetReset): void
     {
         if (! \in_array($offsetReset, ['latest', 'earliest'], true)) {
             throw new Exception\Config('Set offset reset value is invalid, must set it `latest` or `earliest`');
@@ -80,6 +105,11 @@ class ConsumerConfig extends Config
         static::$options['offsetReset'] = $offsetReset;
     }
 
+    /**
+     * @return string[]
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function getTopics(): array
     {
         $topics = $this->ietTopics();
@@ -91,6 +121,11 @@ class ConsumerConfig extends Config
         return $topics;
     }
 
+    /**
+     * @param string[] $topics
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function setTopics(array $topics): void
     {
         if (empty($topics)) {
@@ -105,7 +140,7 @@ class ConsumerConfig extends Config
         $this->runtimeOptions['consume_mode'] = $mode;
     }
 
-    public function getConsumeMode()
+    public function getConsumeMode(): int
     {
         return $this->runtimeOptions['consume_mode'];
     }

--- a/src/ConsumerConfig.php
+++ b/src/ConsumerConfig.php
@@ -44,7 +44,7 @@ class ConsumerConfig extends Config
      */
     public function getGroupId(): string
     {
-        $groupId = trim($this->ietGroupId());
+        $groupId = \trim($this->ietGroupId());
 
         if ($groupId === false || $groupId === '') {
             throw new Exception\Config('Get group id value is invalid, must set it not empty string');
@@ -58,7 +58,7 @@ class ConsumerConfig extends Config
      */
     public function setGroupId(string $groupId): void
     {
-        $groupId = trim($groupId);
+        $groupId = \trim($groupId);
 
         if ($groupId === false || $groupId === '') {
             throw new Exception\Config('Set group id value is invalid, must set it not empty string');

--- a/src/ConsumerConfig.php
+++ b/src/ConsumerConfig.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 /**
@@ -66,13 +68,11 @@ class ConsumerConfig extends Config
     }
 
     /**
-     * @param int|string|float $sessionTimeout
-     *
      * @throws \Kafka\Exception\Config
      */
-    public function setSessionTimeout($sessionTimeout): void
+    public function setSessionTimeout(int $sessionTimeout): void
     {
-        if (! is_numeric($sessionTimeout) || $sessionTimeout < 1 || $sessionTimeout > 3600000) {
+        if ($sessionTimeout < 1 || $sessionTimeout > 3600000) {
             throw new Exception\Config('Set session timeout value is invalid, must set it 1 .. 3600000');
         }
 
@@ -80,13 +80,11 @@ class ConsumerConfig extends Config
     }
 
     /**
-     * @param int|string|float $rebalanceTimeout
-     *
      * @throws \Kafka\Exception\Config
      */
-    public function setRebalanceTimeout($rebalanceTimeout): void
+    public function setRebalanceTimeout(int $rebalanceTimeout): void
     {
-        if (! is_numeric($rebalanceTimeout) || $rebalanceTimeout < 1 || $rebalanceTimeout > 3600000) {
+        if ($rebalanceTimeout < 1 || $rebalanceTimeout > 3600000) {
             throw new Exception\Config('Set rebalance timeout value is invalid, must set it 1 .. 3600000');
         }
 

--- a/src/ConsumerConfig.php
+++ b/src/ConsumerConfig.php
@@ -135,6 +135,13 @@ class ConsumerConfig extends Config
 
     public function setConsumeMode(int $mode): void
     {
+        if (! \in_array($mode, [self::CONSUME_AFTER_COMMIT_OFFSET, self::CONSUME_BEFORE_COMMIT_OFFSET], true)) {
+            throw new Exception\Config(
+                'Invalid consume mode given, it must be either "ConsumerConfig::CONSUME_AFTER_COMMIT_OFFSET" or '
+                . '"ConsumerConfig::CONSUME_BEFORE_COMMIT_OFFSET"'
+            );
+        }
+
         $this->runtimeOptions['consume_mode'] = $mode;
     }
 

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 class Exception extends \RuntimeException

--- a/src/Exception/Config.php
+++ b/src/Exception/Config.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Exception;
 
 use Kafka\Exception;

--- a/src/Exception/Config.php
+++ b/src/Exception/Config.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kafka\Exception;
 
-use \Kafka\Exception;
+use Kafka\Exception;
 
 class Config extends Exception
 {

--- a/src/Exception/NotSupported.php
+++ b/src/Exception/NotSupported.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Exception;
 
 use Kafka\Exception;

--- a/src/Exception/NotSupported.php
+++ b/src/Exception/NotSupported.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kafka\Exception;
 
-use \Kafka\Exception;
+use Kafka\Exception;
 
 class NotSupported extends Exception
 {

--- a/src/Exception/Protocol.php
+++ b/src/Exception/Protocol.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kafka\Exception;
 
-use \Kafka\Exception;
+use Kafka\Exception;
 
 class Protocol extends Exception
 {

--- a/src/Exception/Protocol.php
+++ b/src/Exception/Protocol.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Exception;
 
 use Kafka\Exception;

--- a/src/Exception/Socket.php
+++ b/src/Exception/Socket.php
@@ -2,7 +2,7 @@
 
 namespace Kafka\Exception;
 
-use \Kafka\Exception;
+use Kafka\Exception;
 
 class Socket extends Exception
 {

--- a/src/Exception/Socket.php
+++ b/src/Exception/Socket.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Exception;
 

--- a/src/LoggerTrait.php
+++ b/src/LoggerTrait.php
@@ -9,12 +9,10 @@ trait LoggerTrait
     /**
      * System is unusable.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency(string $message, array $context = []): void
     {
         $this->log(LogLevel::EMERGENCY, $message, $context);
     }
@@ -25,12 +23,10 @@ trait LoggerTrait
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert(string $message, array $context = []): void
     {
         $this->log(LogLevel::ALERT, $message, $context);
     }
@@ -40,12 +36,10 @@ trait LoggerTrait
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical(string $message, array $context = []): void
     {
         $this->log(LogLevel::CRITICAL, $message, $context);
     }
@@ -54,12 +48,10 @@ trait LoggerTrait
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function error($message, array $context = [])
+    public function error(string $message, array $context = []): void
     {
         $this->log(LogLevel::ERROR, $message, $context);
     }
@@ -70,12 +62,10 @@ trait LoggerTrait
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning(string $message, array $context = []): void
     {
         $this->log(LogLevel::WARNING, $message, $context);
     }
@@ -83,12 +73,10 @@ trait LoggerTrait
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice(string $message, array $context = []): void
     {
         $this->log(LogLevel::NOTICE, $message, $context);
     }
@@ -98,12 +86,10 @@ trait LoggerTrait
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function info($message, array $context = [])
+    public function info(string $message, array $context = []): void
     {
         $this->log(LogLevel::INFO, $message, $context);
     }
@@ -111,12 +97,10 @@ trait LoggerTrait
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug(string $message, array $context = []): void
     {
         $this->log(LogLevel::DEBUG, $message, $context);
     }
@@ -126,11 +110,10 @@ trait LoggerTrait
      *
      * @param mixed  $level
      * @param string $message
-     * @param array  $context
+     * @param mixed[] $context
      *
-     * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         if ($this->logger === null) {
             $this->logger = new NullLogger();

--- a/src/LoggerTrait.php
+++ b/src/LoggerTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Psr\Log\LogLevel;

--- a/src/LoggerTrait.php
+++ b/src/LoggerTrait.php
@@ -132,7 +132,7 @@ trait LoggerTrait
      */
     public function log($level, $message, array $context = [])
     {
-        if ($this->logger == null) {
+        if ($this->logger === null) {
             $this->logger = new NullLogger();
         }
         $this->logger->log($level, $message, $context);

--- a/src/LoggerTrait.php
+++ b/src/LoggerTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace Kafka;
 
-use \Psr\Log\NullLogger;
-use \Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+use Psr\Log\LogLevel;
 
 trait LoggerTrait
 {

--- a/src/LoggerTrait.php
+++ b/src/LoggerTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace Kafka;
 
-use Psr\Log\NullLogger;
 use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 
 trait LoggerTrait
 {

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -4,11 +4,12 @@ namespace Kafka;
 use Amp\Loop;
 use Kafka\Producer\Process;
 use Kafka\Producer\SyncProcess;
+use Psr\Log\LoggerAwareTrait;
 
 class Producer
 {
-    use \Psr\Log\LoggerAwareTrait;
-    use \Kafka\LoggerTrait;
+    use LoggerAwareTrait;
+    use LoggerTrait;
 
     /**
      * @var Process|SyncProcess

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Amp\Loop;

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -22,7 +22,11 @@ class Producer
     }
 
     /**
-     * @param array|bool $data
+     * @param mixed[]|bool $data
+     *
+     * @return mixed[]|null
+     *
+     * @throws \Kafka\Exception
      */
     public function send($data = true): ?array
     {
@@ -39,6 +43,13 @@ class Producer
         return null;
     }
 
+    /**
+     * @param mixed[] $data
+     *
+     * @return mixed[]
+     *
+     * @throws \Kafka\Exception
+     */
     private function sendSynchronously(array $data): array
     {
         if (! $this->process instanceof SyncProcess) {
@@ -48,6 +59,9 @@ class Producer
         return $this->process->send($data);
     }
 
+    /**
+     * @throws \Kafka\Exception
+     */
     private function sendAsynchronously(bool $startLoop): void
     {
         if ($this->process instanceof SyncProcess) {

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -127,7 +127,7 @@ class Process
             }
         }
 
-        if (count($brokerHost) == 0) {
+        if (count($brokerHost) === 0) {
             throw new \Kafka\Exception('No valid broker configured');
         }
 

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Producer;
 
 use Amp\Loop;
@@ -217,7 +219,7 @@ class Process
         $sendData = $this->convertMessage($data);
 
         foreach ($sendData as $brokerId => $topicList) {
-            $connect = $broker->getDataConnect($brokerId);
+            $connect = $broker->getDataConnect((string) $brokerId);
 
             if ($connect === null) {
                 return $context;

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -232,7 +232,7 @@ class Process
                 'compression'  => $compression,
             ];
 
-            $this->debug("Send message start, params:" . json_encode($params));
+            $this->debug('Send message start, params:' . json_encode($params));
             $requestData = Protocol::encode(Protocol::PRODUCE_REQUEST, $params);
 
             if ($requiredAck === 0) { // If it is 0 the server will not send any response

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -5,11 +5,14 @@ use Amp\Loop;
 use Kafka\Broker;
 use Kafka\ProducerConfig;
 use Kafka\Protocol;
+use Psr\Log\LoggerAwareTrait;
+use Kafka\LoggerTrait;
+use Kafka\Exception;
 
 class Process
 {
-    use \Psr\Log\LoggerAwareTrait;
-    use \Kafka\LoggerTrait;
+    use LoggerAwareTrait;
+    use LoggerTrait;
 
     /**
      * @var callable|null
@@ -128,7 +131,7 @@ class Process
         }
 
         if (count($brokerHost) === 0) {
-            throw new \Kafka\Exception('No valid broker configured');
+            throw new Exception('No valid broker configured');
         }
 
         shuffle($brokerHost);

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -3,11 +3,11 @@ namespace Kafka\Producer;
 
 use Amp\Loop;
 use Kafka\Broker;
+use Kafka\Exception;
+use Kafka\LoggerTrait;
 use Kafka\ProducerConfig;
 use Kafka\Protocol;
 use Psr\Log\LoggerAwareTrait;
-use Kafka\LoggerTrait;
-use Kafka\Exception;
 
 class Process
 {

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -126,17 +126,17 @@ class Process
         $brokerList = ProducerConfig::getInstance()->getMetadataBrokerList();
         $brokerHost = [];
 
-        foreach (explode(',', $brokerList) as $key => $val) {
-            if (trim($val)) {
+        foreach (\explode(',', $brokerList) as $key => $val) {
+            if (\trim($val)) {
                 $brokerHost[] = $val;
             }
         }
 
-        if (count($brokerHost) === 0) {
+        if (\count($brokerHost) === 0) {
             throw new Exception('No valid broker configured');
         }
 
-        shuffle($brokerHost);
+        \shuffle($brokerHost);
         $broker = $this->getBroker();
 
         foreach ($brokerHost as $host) {
@@ -144,7 +144,7 @@ class Process
 
             if ($socket !== null) {
                 $params = [];
-                $this->debug('Start sync metadata request params:' . json_encode($params));
+                $this->debug('Start sync metadata request params:' . \json_encode($params));
                 $requestData = Protocol::encode(Protocol::METADATA_REQUEST, $params);
                 $socket->write($requestData);
                 return;
@@ -152,7 +152,7 @@ class Process
         }
 
         throw new Exception(
-            sprintf(
+            \sprintf(
                 'It was not possible to establish a connection for metadata with the brokers "%s"',
                 $brokerList
             )
@@ -166,10 +166,10 @@ class Process
      */
     protected function processRequest(string $data, int $fd): void
     {
-        $correlationId = Protocol\Protocol::unpack(Protocol\Protocol::BIT_B32, substr($data, 0, 4));
+        $correlationId = Protocol\Protocol::unpack(Protocol\Protocol::BIT_B32, \substr($data, 0, 4));
         switch ($correlationId) {
             case Protocol::METADATA_REQUEST:
-                $result = Protocol::decode(Protocol::METADATA_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::METADATA_REQUEST, \substr($data, 4));
 
                 if (! isset($result['brokers'], $result['topics'])) {
                     $this->error('Get metadata is fail, brokers or topics is null.');
@@ -183,7 +183,7 @@ class Process
 
                 break;
             case Protocol::PRODUCE_REQUEST:
-                $result = Protocol::decode(Protocol::PRODUCE_REQUEST, substr($data, 4));
+                $result = Protocol::decode(Protocol::PRODUCE_REQUEST, \substr($data, 4));
                 $this->succProduce($result, $fd);
                 break;
             default:
@@ -232,7 +232,7 @@ class Process
                 'compression'  => $compression,
             ];
 
-            $this->debug('Send message start, params:' . json_encode($params));
+            $this->debug('Send message start, params:' . \json_encode($params));
             $requestData = Protocol::encode(Protocol::PRODUCE_REQUEST, $params);
 
             if ($requiredAck === 0) { // If it is 0 the server will not send any response
@@ -251,7 +251,7 @@ class Process
      */
     protected function succProduce(array $result, int $fd): void
     {
-        $msg = sprintf('Send message sucess, result: %s', json_encode($result));
+        $msg = \sprintf('Send message sucess, result: %s', \json_encode($result));
         $this->debug($msg);
 
         if ($this->success !== null) {
@@ -305,7 +305,7 @@ class Process
         $topicInfo = $broker->getTopics();
 
         foreach ($data as $value) {
-            if (! isset($value['topic']) || ! trim($value['topic'])) {
+            if (! isset($value['topic']) || ! \trim($value['topic'])) {
                 continue;
             }
 
@@ -313,13 +313,13 @@ class Process
                 continue;
             }
 
-            if (! isset($value['value']) || ! trim($value['value'])) {
+            if (! isset($value['value']) || ! \trim($value['value'])) {
                 continue;
             }
 
             $topicMeta = $topicInfo[$value['topic']];
-            $partNums  = array_keys($topicMeta);
-            shuffle($partNums);
+            $partNums  = \array_keys($topicMeta);
+            \shuffle($partNums);
 
             $partId = ! isset($value['partId'], $topicMeta[$value['partId']]) ? $partNums[0] : $value['partId'];
 
@@ -335,7 +335,7 @@ class Process
             }
 
             $partition['partition_id'] = $partId;
-            if (trim($value['key'] ?? '') !== '') {
+            if (\trim($value['key'] ?? '') !== '') {
                 $partition['messages'][] = ['value' => $value['value'], 'key' => $value['key']];
             } else {
                 $partition['messages'][] = $value['value'];

--- a/src/Producer/State.php
+++ b/src/Producer/State.php
@@ -2,10 +2,12 @@
 namespace Kafka\Producer;
 
 use Amp\Loop;
+use Kafka\SingletonTrait;
+use Kafka\ProducerConfig;
 
 class State
 {
-    use \Kafka\SingletonTrait;
+    use SingletonTrait;
 
     public const REQUEST_METADATA = 1;
     public const REQUEST_PRODUCE  = 2;
@@ -38,7 +40,7 @@ class State
         // instances clear
 
         // init requests
-        $config = \Kafka\ProducerConfig::getInstance();
+        $config = ProducerConfig::getInstance();
 
         foreach ($this->requests as $request => $option) {
             switch ($request) {

--- a/src/Producer/State.php
+++ b/src/Producer/State.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Producer;
 
 use Amp\Loop;
@@ -56,8 +58,9 @@ class State
     public function start(): void
     {
         foreach ($this->requests as $request => $option) {
-            $interval = isset($option['interval']) ? $option['interval'] : 200;
-            Loop::repeat($interval, function ($watcherId) use ($request, $option): void {
+            $interval = $option['interval'] ?? 200;
+
+            Loop::repeat((int) $interval, function (string $watcherId) use ($request, $option): void {
                 if ($this->checkRun($request) && $option['func'] !== null) {
                     $this->processing($request, $option['func']());
                 }

--- a/src/Producer/State.php
+++ b/src/Producer/State.php
@@ -2,8 +2,8 @@
 namespace Kafka\Producer;
 
 use Amp\Loop;
-use Kafka\SingletonTrait;
 use Kafka\ProducerConfig;
+use Kafka\SingletonTrait;
 
 class State
 {

--- a/src/Producer/State.php
+++ b/src/Producer/State.php
@@ -19,47 +19,45 @@ class State
     public const STATUS_PROCESS = 8;
     public const STATUS_FINISH  = 16;
 
+    /**
+     * @var mixed[]
+     */
     private $callStatus = [];
 
+    /**
+     * @var mixed[][]
+     */
     private $requests = [
         self::REQUEST_METADATA => [],
         self::REQUEST_PRODUCE => [],
     ];
 
-    public function init()
+    public function init(): void
     {
         $this->callStatus = [
-            self::REQUEST_METADATA => [
-                'status'=> self::STATUS_LOOP,
-            ],
-            self::REQUEST_PRODUCE => [
-                'status'=> self::STATUS_LOOP,
-            ],
+            self::REQUEST_METADATA => ['status' => self::STATUS_LOOP],
+            self::REQUEST_PRODUCE  => ['status' => self::STATUS_LOOP],
         ];
 
-        // instances clear
+        $config = $this->getConfig();
 
-        // init requests
-        $config = ProducerConfig::getInstance();
-
-        foreach ($this->requests as $request => $option) {
-            switch ($request) {
-                case self::REQUEST_METADATA:
-                    $this->requests[$request]['interval'] = $config->getMetadataRefreshIntervalMs();
-                    break;
-                default:
-                    $interval = $config->getIsAsyn() ? $config->getProduceInterval() : 1;
-
-                    $this->requests[$request]['interval'] = $interval;
+        foreach (array_keys($this->requests) as $request) {
+            if ($request === self::REQUEST_METADATA) {
+                $this->requests[$request]['interval'] = $config->getMetadataRefreshIntervalMs();
+                break;
             }
+
+            $interval = $config->getIsAsyn() ? $config->getProduceInterval() : 1;
+
+            $this->requests[$request]['interval'] = $interval;
         }
     }
 
-    public function start()
+    public function start(): void
     {
         foreach ($this->requests as $request => $option) {
             $interval = isset($option['interval']) ? $option['interval'] : 200;
-            Loop::repeat($interval, function ($watcherId) use ($request, $option) {
+            Loop::repeat($interval, function ($watcherId) use ($request, $option): void {
                 if ($this->checkRun($request) && $option['func'] !== null) {
                     $this->processing($request, $option['func']());
                 }
@@ -76,19 +74,23 @@ class State
         }
     }
 
-    public function succRun($key, $context = null)
+    /**
+     * @param mixed|null $context
+     */
+    public function succRun(int $key, $context = null): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
+        $config = $this->getConfig();
         $isAsyn = $config->getIsAsyn();
 
         if (! isset($this->callStatus[$key])) {
-            return false;
+            return;
         }
 
         switch ($key) {
             case self::REQUEST_METADATA:
                 $this->callStatus[$key]['status'] = (self::STATUS_LOOP | self::STATUS_FINISH);
-                if ($context) { // if kafka broker is change
+
+                if ($context !== null) { // if kafka broker is change
                     $this->recover();
                 }
                 break;
@@ -117,7 +119,7 @@ class State
         }
     }
 
-    public function failRun($key, $context = null): void
+    public function failRun(int $key): void
     {
         if (! isset($this->callStatus[$key])) {
             return;
@@ -133,14 +135,17 @@ class State
         }
     }
 
-    public function setCallback($callbacks)
+    /**
+     * @param callable[] $callbacks
+     */
+    public function setCallback(array $callbacks): void
     {
         foreach ($callbacks as $request => $callback) {
             $this->requests[$request]['func'] = $callback;
         }
     }
 
-    public function recover()
+    public function recover(): void
     {
         $this->callStatus = [
             self::REQUEST_METADATA => $this->callStatus[self::REQUEST_METADATA],
@@ -150,7 +155,7 @@ class State
         ];
     }
 
-    protected function checkRun($key)
+    protected function checkRun(int $key): bool
     {
         if (! isset($this->callStatus[$key])) {
             return false;
@@ -186,12 +191,17 @@ class State
 
                 return false;
         }
+
+        return false;
     }
 
-    protected function processing($key, $context)
+    /**
+     * @param mixed $context
+     */
+    protected function processing(int $key, $context): void
     {
         if (! isset($this->callStatus[$key])) {
-            return false;
+            return;
         }
 
         // set process start time
@@ -204,15 +214,25 @@ class State
                 if (empty($context)) {
                     break;
                 }
+
                 $this->callStatus[$key]['status'] |= self::STATUS_PROCESS;
-                $contextStatus                     = [];
+
+                $contextStatus = [];
+
                 if (is_array($context)) {
                     foreach ($context as $fd) {
                         $contextStatus[$fd] = self::STATUS_PROCESS;
                     }
+
                     $this->callStatus[$key]['context'] = $contextStatus;
                 }
+
                 break;
         }
+    }
+
+    private function getConfig(): ProducerConfig
+    {
+        return ProducerConfig::getInstance();
     }
 }

--- a/src/Producer/State.php
+++ b/src/Producer/State.php
@@ -43,7 +43,7 @@ class State
 
         $config = $this->getConfig();
 
-        foreach (array_keys($this->requests) as $request) {
+        foreach (\array_keys($this->requests) as $request) {
             if ($request === self::REQUEST_METADATA) {
                 $this->requests[$request]['interval'] = $config->getMetadataRefreshIntervalMs();
                 break;
@@ -208,7 +208,7 @@ class State
         }
 
         // set process start time
-        $this->callStatus[$key]['time'] = microtime(true);
+        $this->callStatus[$key]['time'] = \microtime(true);
         switch ($key) {
             case self::REQUEST_METADATA:
                 $this->callStatus[$key]['status'] |= self::STATUS_PROCESS;
@@ -222,7 +222,7 @@ class State
 
                 $contextStatus = [];
 
-                if (is_array($context)) {
+                if (\is_array($context)) {
                     foreach ($context as $fd) {
                         $contextStatus[$fd] = self::STATUS_PROCESS;
                     }

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -85,7 +85,7 @@ class SyncProcess
             }
         }
 
-        if (count($brokerHost) == 0) {
+        if (count($brokerHost) === 0) {
             throw new \Kafka\Exception('No valid broker configured');
         }
 

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Producer;
 
 use Kafka\Broker;
@@ -53,7 +55,7 @@ class SyncProcess
         $sendData = $this->convertMessage($data);
         $result   = [];
         foreach ($sendData as $brokerId => $topicList) {
-            $connect = $broker->getDataConnect($brokerId, true);
+            $connect = $broker->getDataConnect((string) $brokerId, true);
 
             if ($connect === null) {
                 return [];

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -68,15 +68,15 @@ class SyncProcess
                 'compression'  => $compression,
             ];
 
-            $this->debug('Send message start, params:' . json_encode($params));
+            $this->debug('Send message start, params:' . \json_encode($params));
             $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::PRODUCE_REQUEST, $params);
             $connect->write($requestData);
 
             if ($requiredAck !== 0) { // If it is 0 the server will not send any response
                 $dataLen       = Protocol::unpack(Protocol::BIT_B32, $connect->read(4));
                 $data          = $connect->read($dataLen);
-                $correlationId = Protocol::unpack(Protocol::BIT_B32, substr($data, 0, 4));
-                $ret           = \Kafka\Protocol::decode(\Kafka\Protocol::PRODUCE_REQUEST, substr($data, 4));
+                $correlationId = Protocol::unpack(Protocol::BIT_B32, \substr($data, 0, 4));
+                $ret           = \Kafka\Protocol::decode(\Kafka\Protocol::PRODUCE_REQUEST, \substr($data, 4));
 
                 $result[] = $ret;
             }
@@ -92,17 +92,17 @@ class SyncProcess
         $brokerList = ProducerConfig::getInstance()->getMetadataBrokerList();
         $brokerHost = [];
 
-        foreach (explode(',', $brokerList) as $key => $val) {
-            if (trim($val)) {
+        foreach (\explode(',', $brokerList) as $key => $val) {
+            if (\trim($val)) {
                 $brokerHost[] = $val;
             }
         }
 
-        if (count($brokerHost) === 0) {
+        if (\count($brokerHost) === 0) {
             throw new Exception('No valid broker configured');
         }
 
-        shuffle($brokerHost);
+        \shuffle($brokerHost);
         $broker = $this->getBroker();
 
         foreach ($brokerHost as $host) {
@@ -113,13 +113,13 @@ class SyncProcess
             }
 
             $params = [];
-            $this->debug('Start sync metadata request params:' . json_encode($params));
+            $this->debug('Start sync metadata request params:' . \json_encode($params));
             $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::METADATA_REQUEST, $params);
             $socket->write($requestData);
             $dataLen       = Protocol::unpack(Protocol::BIT_B32, $socket->read(4));
             $data          = $socket->read($dataLen);
-            $correlationId = Protocol::unpack(Protocol::BIT_B32, substr($data, 0, 4));
-            $result        = \Kafka\Protocol::decode(\Kafka\Protocol::METADATA_REQUEST, substr($data, 4));
+            $correlationId = Protocol::unpack(Protocol::BIT_B32, \substr($data, 0, 4));
+            $result        = \Kafka\Protocol::decode(\Kafka\Protocol::METADATA_REQUEST, \substr($data, 4));
 
             if (! isset($result['brokers'], $result['topics'])) {
                 throw new \Kafka\Exception('Get metadata is fail, brokers or topics is null.');
@@ -132,7 +132,7 @@ class SyncProcess
         }
 
         throw new \Kafka\Exception(
-            sprintf(
+            \sprintf(
                 'It was not possible to establish a connection for metadata with the brokers "%s"',
                 $brokerList
             )
@@ -151,7 +151,7 @@ class SyncProcess
         $topicInfos = $broker->getTopics();
 
         foreach ($data as $value) {
-            if (! isset($value['topic']) || ! trim($value['topic'])) {
+            if (! isset($value['topic']) || ! \trim($value['topic'])) {
                 continue;
             }
 
@@ -159,13 +159,13 @@ class SyncProcess
                 continue;
             }
 
-            if (! isset($value['value']) || ! trim($value['value'])) {
+            if (! isset($value['value']) || ! \trim($value['value'])) {
                 continue;
             }
 
             $topicMeta = $topicInfos[$value['topic']];
-            $partNums  = array_keys($topicMeta);
-            shuffle($partNums);
+            $partNums  = \array_keys($topicMeta);
+            \shuffle($partNums);
 
             $partId = isset($value['partId'], $topicMeta[$value['partId']]) ? $value['partId'] : $partNums[0];
 
@@ -182,7 +182,7 @@ class SyncProcess
 
             $partition['partition_id'] = $partId;
 
-            if (trim($value['key'] ?? '') !== '') {
+            if (\trim($value['key'] ?? '') !== '') {
                 $partition['messages'][] = ['value' => $value['value'], 'key' => $value['key']];
             } else {
                 $partition['messages'][] = $value['value'];

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -68,7 +68,7 @@ class SyncProcess
                 'compression'  => $compression,
             ];
 
-            $this->debug("Send message start, params:" . json_encode($params));
+            $this->debug('Send message start, params:' . json_encode($params));
             $requestData = \Kafka\Protocol::encode(\Kafka\Protocol::PRODUCE_REQUEST, $params);
             $connect->write($requestData);
 

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -4,11 +4,14 @@ namespace Kafka\Producer;
 use Kafka\Broker;
 use Kafka\ProducerConfig;
 use Kafka\Protocol\Protocol;
+use Psr\Log\LoggerAwareTrait;
+use Kafka\LoggerTrait;
+use Kafka\Exception;
 
 class SyncProcess
 {
-    use \Psr\Log\LoggerAwareTrait;
-    use \Kafka\LoggerTrait;
+    use LoggerAwareTrait;
+    use LoggerTrait;
 
     public function __construct()
     {
@@ -86,7 +89,7 @@ class SyncProcess
         }
 
         if (count($brokerHost) === 0) {
-            throw new \Kafka\Exception('No valid broker configured');
+            throw new Exception('No valid broker configured');
         }
 
         shuffle($brokerHost);

--- a/src/ProducerConfig.php
+++ b/src/ProducerConfig.php
@@ -21,6 +21,9 @@ class ProducerConfig extends Config
         Produce::COMPRESSION_SNAPPY,
     ];
 
+    /**
+     * @var mixed[]
+     */
     protected static $defaults = [
         'requiredAck'     => 1,
         'timeout'         => 5000,
@@ -30,6 +33,11 @@ class ProducerConfig extends Config
         'compression'     => Protocol\Protocol::COMPRESSION_NONE,
     ];
 
+    /**
+     * @param float|int|string $requestTimeout
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function setRequestTimeout($requestTimeout): void
     {
         if (! is_numeric($requestTimeout) || $requestTimeout < 1 || $requestTimeout > 900000) {
@@ -39,6 +47,11 @@ class ProducerConfig extends Config
         static::$options['requestTimeout'] = $requestTimeout;
     }
 
+    /**
+     * @param float|int|string $produceInterval
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function setProduceInterval($produceInterval): void
     {
         if (! is_numeric($produceInterval) || $produceInterval < 1 || $produceInterval > 900000) {
@@ -48,6 +61,11 @@ class ProducerConfig extends Config
         static::$options['produceInterval'] = $produceInterval;
     }
 
+    /**
+     * @param float|int|string $timeout
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function setTimeout($timeout): void
     {
         if (! is_numeric($timeout) || $timeout < 1 || $timeout > 900000) {
@@ -57,6 +75,11 @@ class ProducerConfig extends Config
         static::$options['timeout'] = $timeout;
     }
 
+    /**
+     * @param float|int|string $requiredAck
+     *
+     * @throws \Kafka\Exception\Config
+     */
     public function setRequiredAck($requiredAck): void
     {
         if (! is_numeric($requiredAck) || $requiredAck < -1 || $requiredAck > 1000) {
@@ -66,12 +89,8 @@ class ProducerConfig extends Config
         static::$options['requiredAck'] = $requiredAck;
     }
 
-    public function setIsAsyn($asyn): void
+    public function setIsAsyn(bool $asyn): void
     {
-        if (! is_bool($asyn)) {
-            throw new Exception\Config('Set isAsyn value is invalid, must set it bool value');
-        }
-
         static::$options['isAsyn'] = $asyn;
     }
 

--- a/src/ProducerConfig.php
+++ b/src/ProducerConfig.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Kafka\Protocol\Produce;
@@ -34,13 +36,11 @@ class ProducerConfig extends Config
     ];
 
     /**
-     * @param float|int|string $requestTimeout
-     *
      * @throws \Kafka\Exception\Config
      */
-    public function setRequestTimeout($requestTimeout): void
+    public function setRequestTimeout(int $requestTimeout): void
     {
-        if (! is_numeric($requestTimeout) || $requestTimeout < 1 || $requestTimeout > 900000) {
+        if ($requestTimeout < 1 || $requestTimeout > 900000) {
             throw new Exception\Config('Set request timeout value is invalid, must set it 1 .. 900000');
         }
 
@@ -48,13 +48,11 @@ class ProducerConfig extends Config
     }
 
     /**
-     * @param float|int|string $produceInterval
-     *
      * @throws \Kafka\Exception\Config
      */
-    public function setProduceInterval($produceInterval): void
+    public function setProduceInterval(int $produceInterval): void
     {
-        if (! is_numeric($produceInterval) || $produceInterval < 1 || $produceInterval > 900000) {
+        if ($produceInterval < 1 || $produceInterval > 900000) {
             throw new Exception\Config('Set produce interval timeout value is invalid, must set it 1 .. 900000');
         }
 
@@ -62,13 +60,11 @@ class ProducerConfig extends Config
     }
 
     /**
-     * @param float|int|string $timeout
-     *
      * @throws \Kafka\Exception\Config
      */
-    public function setTimeout($timeout): void
+    public function setTimeout(int $timeout): void
     {
-        if (! is_numeric($timeout) || $timeout < 1 || $timeout > 900000) {
+        if ($timeout < 1 || $timeout > 900000) {
             throw new Exception\Config('Set timeout value is invalid, must set it 1 .. 900000');
         }
 
@@ -76,13 +72,11 @@ class ProducerConfig extends Config
     }
 
     /**
-     * @param float|int|string $requiredAck
-     *
      * @throws \Kafka\Exception\Config
      */
-    public function setRequiredAck($requiredAck): void
+    public function setRequiredAck(int $requiredAck): void
     {
-        if (! is_numeric($requiredAck) || $requiredAck < -1 || $requiredAck > 1000) {
+        if ($requiredAck < -1 || $requiredAck > 1000) {
             throw new Exception\Config('Set required ack value is invalid, must set it -1 .. 1000');
         }
 

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -151,7 +151,7 @@ class Protocol
         57 => 'The user-specified log directory is not found in the broker config.',
         58 => 'SASL Authentication failed.',
         59 => 'This exception is raised by the broker if it could not locate the producer metadata associated with the producerId in question',
-        60 => 'A partition reassignment is in progress'
+        60 => 'A partition reassignment is in progress',
     ];
 
     /**

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -159,7 +159,7 @@ class Protocol
      */
     protected static $objects = [];
 
-    public static function init(string $version, LoggerInterface $logger = null): void
+    public static function init(string $version, ?LoggerInterface $logger = null): void
     {
         $class = [
             Protocol\Protocol::PRODUCE_REQUEST           => Protocol\Produce::class,

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -189,6 +189,8 @@ class Protocol
     }
 
     /**
+     * @param mixed[] $payloads
+     *
      * @throws \Kafka\Exception
      */
     public static function encode(int $key, array $payloads): string
@@ -201,6 +203,8 @@ class Protocol
     }
 
     /**
+     * @return mixed[]
+     *
      * @throws \Kafka\Exception
      */
     public static function decode(int $key, string $data): array
@@ -212,9 +216,6 @@ class Protocol
         return self::$objects[$key]->decode($data);
     }
 
-    /**
-     * get error
-     */
     public static function getError(int $errCode): string
     {
         if (! isset(self::PROTOCOL_ERROR_MAP[$errCode])) {

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -194,7 +194,7 @@ class Protocol
     public static function encode(int $key, array $payloads): string
     {
         if (! isset(self::$objects[$key])) {
-            throw new \Kafka\Exception('Not support api key, key:' . $key);
+            throw new Exception('Not support api key, key:' . $key);
         }
 
         return self::$objects[$key]->encode($payloads);

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Psr\Log\LoggerInterface;

--- a/src/Protocol/ApiVersions.php
+++ b/src/Protocol/ApiVersions.php
@@ -3,6 +3,9 @@ namespace Kafka\Protocol;
 
 class ApiVersions extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     */
     public function encode(array $payloads = []): string
     {
         $header = $this->requestHeader('kafka-php', self::API_VERSIONS_REQUEST, self::API_VERSIONS_REQUEST);
@@ -10,6 +13,9 @@ class ApiVersions extends Protocol
         return self::encodeString($header, self::PACK_INT32);
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset      = 0;
@@ -20,10 +26,13 @@ class ApiVersions extends Protocol
 
         return [
             'apiVersions' => $apiVersions['data'],
-            'errorCode'  => $errcode,
+            'errorCode'   => $errcode,
         ];
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function apiVersion(string $data): array
     {
         $offset     = 0;
@@ -36,11 +45,7 @@ class ApiVersions extends Protocol
 
         return [
             'length' => $offset,
-            'data'   => [
-                $apiKey,
-                $minVersion,
-                $maxVersion,
-            ],
+            'data'   => [$apiKey, $minVersion, $maxVersion],
         ];
     }
 }

--- a/src/Protocol/ApiVersions.php
+++ b/src/Protocol/ApiVersions.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Protocol;
 
 class ApiVersions extends Protocol

--- a/src/Protocol/ApiVersions.php
+++ b/src/Protocol/ApiVersions.php
@@ -21,9 +21,9 @@ class ApiVersions extends Protocol
     public function decode(string $data): array
     {
         $offset      = 0;
-        $errcode     = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errcode     = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset     += 2;
-        $apiVersions = $this->decodeArray(substr($data, $offset), [$this, 'apiVersion']);
+        $apiVersions = $this->decodeArray(\substr($data, $offset), [$this, 'apiVersion']);
         $offset     += $apiVersions['length'];
 
         return [
@@ -38,11 +38,11 @@ class ApiVersions extends Protocol
     protected function apiVersion(string $data): array
     {
         $offset     = 0;
-        $apiKey     = self::unpack(self::BIT_B16, substr($data, $offset, 2));
+        $apiKey     = self::unpack(self::BIT_B16, \substr($data, $offset, 2));
         $offset    += 2;
-        $minVersion = self::unpack(self::BIT_B16, substr($data, $offset, 2));
+        $minVersion = self::unpack(self::BIT_B16, \substr($data, $offset, 2));
         $offset    += 2;
-        $maxVersion = self::unpack(self::BIT_B16, substr($data, $offset, 2));
+        $maxVersion = self::unpack(self::BIT_B16, \substr($data, $offset, 2));
         $offset    += 2;
 
         return [

--- a/src/Protocol/CommitOffset.php
+++ b/src/Protocol/CommitOffset.php
@@ -64,7 +64,7 @@ class CommitOffset extends Protocol
     public function decode(string $data): array
     {
         $offset  = 0;
-        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'decodeTopic']);
+        $topics  = $this->decodeArray(\substr($data, $offset), [$this, 'decodeTopic']);
         $offset += $topics['length'];
 
         return $topics['data'];
@@ -112,7 +112,7 @@ class CommitOffset extends Protocol
         }
 
         if (! isset($values['timestamp'])) {
-            $values['timestamp'] = time() * 1000;
+            $values['timestamp'] = \time() * 1000;
         }
 
         $version = $this->getApiVersion(self::OFFSET_COMMIT_REQUEST);
@@ -135,10 +135,10 @@ class CommitOffset extends Protocol
     protected function decodeTopic(string $data): array
     {
         $offset    = 0;
-        $topicInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $topicInfo = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset   += $topicInfo['length'];
 
-        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'decodePartition']);
+        $partitions = $this->decodeArray(\substr($data, $offset), [$this, 'decodePartition']);
         $offset    += $partitions['length'];
 
         return [
@@ -157,10 +157,10 @@ class CommitOffset extends Protocol
     {
         $offset = 0;
 
-        $partitionId = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $partitionId = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset     += 4;
 
-        $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset   += 2;
 
         return [

--- a/src/Protocol/CommitOffset.php
+++ b/src/Protocol/CommitOffset.php
@@ -1,16 +1,25 @@
 <?php
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class CommitOffset extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws ProtocolException
+     * @throws NotSupported
+     */
     public function encode(array $payloads = []): string
     {
         if (! isset($payloads['group_id'])) {
-            throw new \Kafka\Exception\Protocol('given commit offset data invalid. `group_id` is undefined.');
+            throw new ProtocolException('given commit offset data invalid. `group_id` is undefined.');
         }
 
         if (! isset($payloads['data'])) {
-            throw new \Kafka\Exception\Protocol('given commit data invalid. `data` is undefined.');
+            throw new ProtocolException('given commit data invalid. `data` is undefined.');
         }
 
         if (! isset($payloads['generation_id'])) {
@@ -47,23 +56,31 @@ class CommitOffset extends Protocol
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset  = 0;
-        $version = $this->getApiVersion(self::OFFSET_REQUEST);
-        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'decodeTopic'], $version);
+        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'decodeTopic']);
         $offset += $topics['length'];
 
         return $topics['data'];
     }
 
+    /**
+     * @param mixed[] $values
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     protected function encodeTopic(array $values): string
     {
         if (! isset($values['topic_name'])) {
-            throw new \Kafka\Exception\Protocol('given commit offset data invalid. `topic_name` is undefined.');
+            throw new ProtocolException('given commit offset data invalid. `topic_name` is undefined.');
         }
         if (! isset($values['partitions'])) {
-            throw new \Kafka\Exception\Protocol('given commit offset data invalid. `partitions` is undefined.');
+            throw new ProtocolException('given commit offset data invalid. `partitions` is undefined.');
         }
 
         $data  = self::encodeString($values['topic_name'], self::PACK_INT16);
@@ -72,14 +89,20 @@ class CommitOffset extends Protocol
         return $data;
     }
 
+    /**
+     * @param mixed[] $values
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     protected function encodePartition(array $values): string
     {
         if (! isset($values['partition'])) {
-            throw new \Kafka\Exception\Protocol('given commit offset data invalid. `partition` is undefined.');
+            throw new ProtocolException('given commit offset data invalid. `partition` is undefined.');
         }
 
         if (! isset($values['offset'])) {
-            throw new \Kafka\Exception\Protocol('given commit offset data invalid. `offset` is undefined.');
+            throw new ProtocolException('given commit offset data invalid. `offset` is undefined.');
         }
 
         if (! isset($values['metadata'])) {
@@ -104,13 +127,16 @@ class CommitOffset extends Protocol
         return $data;
     }
 
-    protected function decodeTopic(string $data, string $version): array
+    /**
+     * @return mixed[]
+     */
+    protected function decodeTopic(string $data): array
     {
         $offset    = 0;
         $topicInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
         $offset   += $topicInfo['length'];
 
-        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'decodePartition'], $version);
+        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'decodePartition']);
         $offset    += $partitions['length'];
 
         return [
@@ -122,7 +148,10 @@ class CommitOffset extends Protocol
         ];
     }
 
-    protected function decodePartition(string $data, string $version): array
+    /**
+     * @return mixed[]
+     */
+    protected function decodePartition(string $data): array
     {
         $offset = 0;
 

--- a/src/Protocol/CommitOffset.php
+++ b/src/Protocol/CommitOffset.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Protocol;
 
 use Kafka\Exception\NotSupported;
@@ -40,14 +42,14 @@ class CommitOffset extends Protocol
         $data = self::encodeString($payloads['group_id'], self::PACK_INT16);
 
         if ($version === self::API_VERSION1) {
-            $data .= self::pack(self::BIT_B32, $payloads['generation_id']);
+            $data .= self::pack(self::BIT_B32, (string) $payloads['generation_id']);
             $data .= self::encodeString($payloads['member_id'], self::PACK_INT16);
         }
 
         if ($version === self::API_VERSION2) {
-            $data .= self::pack(self::BIT_B32, $payloads['generation_id']);
+            $data .= self::pack(self::BIT_B32, (string) $payloads['generation_id']);
             $data .= self::encodeString($payloads['member_id'], self::PACK_INT16);
-            $data .= self::pack(self::BIT_B64, $payloads['retention_time']);
+            $data .= self::pack(self::BIT_B64, (string) $payloads['retention_time']);
         }
 
         $data .= self::encodeArray($payloads['data'], [$this, 'encodeTopic']);
@@ -115,11 +117,11 @@ class CommitOffset extends Protocol
 
         $version = $this->getApiVersion(self::OFFSET_COMMIT_REQUEST);
 
-        $data  = self::pack(self::BIT_B32, $values['partition']);
-        $data .= self::pack(self::BIT_B64, $values['offset']);
+        $data  = self::pack(self::BIT_B32, (string) $values['partition']);
+        $data .= self::pack(self::BIT_B64, (string) $values['offset']);
 
         if ($version === self::API_VERSION1) {
-            $data .= self::pack(self::BIT_B64, $values['timestamp']);
+            $data .= self::pack(self::BIT_B64, (string) $values['timestamp']);
         }
 
         $data .= self::encodeString($values['metadata'], self::PACK_INT16);

--- a/src/Protocol/DescribeGroups.php
+++ b/src/Protocol/DescribeGroups.php
@@ -26,7 +26,7 @@ class DescribeGroups extends Protocol
     public function decode(string $data): array
     {
         $offset  = 0;
-        $groups  = $this->decodeArray(substr($data, $offset), [$this, 'describeGroup']);
+        $groups  = $this->decodeArray(\substr($data, $offset), [$this, 'describeGroup']);
         $offset += $groups['length'];
 
         return $groups['data'];
@@ -38,18 +38,18 @@ class DescribeGroups extends Protocol
     protected function describeGroup(string $data): array
     {
         $offset       = 0;
-        $errorCode    = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode    = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset      += 2;
-        $groupId      = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $groupId      = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset      += $groupId['length'];
-        $state        = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $state        = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset      += $state['length'];
-        $protocolType = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $protocolType = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset      += $protocolType['length'];
-        $protocol     = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $protocol     = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset      += $protocol['length'];
 
-        $members = $this->decodeArray(substr($data, $offset), [$this, 'describeMember']);
+        $members = $this->decodeArray(\substr($data, $offset), [$this, 'describeMember']);
         $offset += $members['length'];
 
         return [
@@ -71,32 +71,32 @@ class DescribeGroups extends Protocol
     protected function describeMember(string $data): array
     {
         $offset     = 0;
-        $memberId   = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $memberId   = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset    += $memberId['length'];
-        $clientId   = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $clientId   = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset    += $clientId['length'];
-        $clientHost = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $clientHost = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset    += $clientHost['length'];
-        $metadata   = $this->decodeString(substr($data, $offset), self::BIT_B32);
+        $metadata   = $this->decodeString(\substr($data, $offset), self::BIT_B32);
         $offset    += $metadata['length'];
-        $assignment = $this->decodeString(substr($data, $offset), self::BIT_B32);
+        $assignment = $this->decodeString(\substr($data, $offset), self::BIT_B32);
         $offset    += $assignment['length'];
 
         $memberAssignment        = $assignment['data'];
         $memberAssignmentOffset  = 0;
-        $version                 = self::unpack(self::BIT_B16_SIGNED, substr($memberAssignment, $memberAssignmentOffset, 2));
+        $version                 = self::unpack(self::BIT_B16_SIGNED, \substr($memberAssignment, $memberAssignmentOffset, 2));
         $memberAssignmentOffset += 2;
-        $partitionAssignments    = $this->decodeArray(substr($memberAssignment, $memberAssignmentOffset), [$this, 'describeResponsePartition']);
+        $partitionAssignments    = $this->decodeArray(\substr($memberAssignment, $memberAssignmentOffset), [$this, 'describeResponsePartition']);
         $memberAssignmentOffset += $partitionAssignments['length'];
-        $userData                = $this->decodeString(substr($memberAssignment, $memberAssignmentOffset), self::BIT_B32);
+        $userData                = $this->decodeString(\substr($memberAssignment, $memberAssignmentOffset), self::BIT_B32);
 
         $metaData     = $metadata['data'];
         $metaOffset   = 0;
-        $version      = self::unpack(self::BIT_B16, substr($metaData, $metaOffset, 2));
+        $version      = self::unpack(self::BIT_B16, \substr($metaData, $metaOffset, 2));
         $metaOffset  += 2;
-        $topics       = $this->decodeArray(substr($metaData, $metaOffset), [$this, 'decodeString'], self::BIT_B16);
+        $topics       = $this->decodeArray(\substr($metaData, $metaOffset), [$this, 'decodeString'], self::BIT_B16);
         $metaOffset  += $topics['length'];
-        $metaUserData = $this->decodeString(substr($metaData, $metaOffset), self::BIT_B32);
+        $metaUserData = $this->decodeString(\substr($metaData, $metaOffset), self::BIT_B32);
 
         return [
             'length' => $offset,
@@ -124,9 +124,9 @@ class DescribeGroups extends Protocol
     protected function describeResponsePartition(string $data): array
     {
         $offset     = 0;
-        $topicName  = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $topicName  = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset    += $topicName['length'];
-        $partitions = $this->decodePrimitiveArray(substr($data, $offset), self::BIT_B32);
+        $partitions = $this->decodePrimitiveArray(\substr($data, $offset), self::BIT_B32);
         $offset    += $partitions['length'];
 
         return [

--- a/src/Protocol/DescribeGroups.php
+++ b/src/Protocol/DescribeGroups.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 

--- a/src/Protocol/DescribeGroups.php
+++ b/src/Protocol/DescribeGroups.php
@@ -2,8 +2,15 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+
 class DescribeGroups extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     */
     public function encode(array $payloads = []): string
     {
         $header = $this->requestHeader('kafka-php', self::DESCRIBE_GROUPS_REQUEST, self::DESCRIBE_GROUPS_REQUEST);
@@ -12,6 +19,9 @@ class DescribeGroups extends Protocol
         return self::encodeString($header . $data, self::PACK_INT32);
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset  = 0;
@@ -21,6 +31,9 @@ class DescribeGroups extends Protocol
         return $groups['data'];
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function describeGroup(string $data): array
     {
         $offset       = 0;
@@ -51,6 +64,9 @@ class DescribeGroups extends Protocol
         ];
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function describeMember(string $data): array
     {
         $offset     = 0;
@@ -101,6 +117,9 @@ class DescribeGroups extends Protocol
         ];
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function describeResponsePartition(string $data): array
     {
         $offset     = 0;

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -2,6 +2,8 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception;
+
 class Fetch extends Protocol
 {
     public function encode(array $payloads = []): string
@@ -213,7 +215,7 @@ class Fetch extends Protocol
             $offset  += $valueRet['length'];
 
             if ($offset !== $messageSize) {
-                throw new \Kafka\Exception(
+                throw new Exception(
                     'pack message fail, message len:' . $messageSize . ' , data unpack offset :' . $offset
                 );
             }

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 
@@ -33,9 +34,9 @@ class Fetch extends Protocol
         }
 
         $header = $this->requestHeader('kafka-php', self::FETCH_REQUEST, self::FETCH_REQUEST);
-        $data   = self::pack(self::BIT_B32, $payloads['replica_id']);
-        $data  .= self::pack(self::BIT_B32, $payloads['max_wait_time']);
-        $data  .= self::pack(self::BIT_B32, $payloads['min_bytes']);
+        $data   = self::pack(self::BIT_B32, (string) $payloads['replica_id']);
+        $data  .= self::pack(self::BIT_B32, (string) $payloads['max_wait_time']);
+        $data  .= self::pack(self::BIT_B32, (string) $payloads['min_bytes']);
         $data  .= self::encodeArray($payloads['data'], [$this, 'encodeFetchTopic']);
         $data   = self::encodeString($header . $data, self::PACK_INT32);
 
@@ -239,7 +240,7 @@ class Fetch extends Protocol
             $keyRet  = $this->decodeString(substr($data, $offset), self::BIT_B32);
             $offset += $keyRet['length'];
 
-            $valueRet = $this->decodeString(substr($data, $offset), self::BIT_B32, $attr & Produce::COMPRESSION_CODEC_MASK);
+            $valueRet = $this->decodeString((string) substr($data, $offset), self::BIT_B32, $attr & Produce::COMPRESSION_CODEC_MASK);
             $offset  += $valueRet['length'];
 
             if ($offset !== $messageSize) {
@@ -289,9 +290,9 @@ class Fetch extends Protocol
             $values['max_bytes'] = 2 * 1024 * 1024;
         }
 
-        $data  = self::pack(self::BIT_B32, $values['partition_id']);
-        $data .= self::pack(self::BIT_B64, $values['offset']);
-        $data .= self::pack(self::BIT_B32, $values['max_bytes']);
+        $data  = self::pack(self::BIT_B32, (string) $values['partition_id']);
+        $data .= self::pack(self::BIT_B64, (string) $values['offset']);
+        $data .= self::pack(self::BIT_B32, (string) $values['max_bytes']);
 
         return $data;
     }

--- a/src/Protocol/Fetch.php
+++ b/src/Protocol/Fetch.php
@@ -53,11 +53,11 @@ class Fetch extends Protocol
         $throttleTime = 0;
 
         if ($version !== self::API_VERSION0) {
-            $throttleTime = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+            $throttleTime = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
             $offset      += 4;
         }
 
-        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'fetchTopic']);
+        $topics  = $this->decodeArray(\substr($data, $offset), [$this, 'fetchTopic']);
         $offset += $topics['length'];
 
         return [
@@ -72,10 +72,10 @@ class Fetch extends Protocol
     protected function fetchTopic(string $data): array
     {
         $offset    = 0;
-        $topicInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $topicInfo = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset   += $topicInfo['length'];
 
-        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'fetchPartition']);
+        $partitions = $this->decodeArray(\substr($data, $offset), [$this, 'fetchPartition']);
         $offset    += $partitions['length'];
 
         return [
@@ -95,20 +95,20 @@ class Fetch extends Protocol
     protected function fetchPartition(string $data): array
     {
         $offset              = 0;
-        $partitionId         = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $partitionId         = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset             += 4;
-        $errorCode           = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode           = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset             += 2;
-        $highwaterMarkOffset = self::unpack(self::BIT_B64, substr($data, $offset, 8));
+        $highwaterMarkOffset = self::unpack(self::BIT_B64, \substr($data, $offset, 8));
         $offset             += 8;
 
-        $messageSetSize = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $messageSetSize = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset        += 4;
 
         $messages = [];
 
         if ($messageSetSize > 0 && $offset < \strlen($data)) {
-            $messages = $this->decodeMessageSetArray(substr($data, $offset, $messageSetSize), $messageSetSize);
+            $messages = $this->decodeMessageSetArray(\substr($data, $offset, $messageSetSize), $messageSetSize);
 
             $offset += $messages['length'];
         }
@@ -178,16 +178,16 @@ class Fetch extends Protocol
      */
     protected function decodeMessageSet(string $data): ?array
     {
-        if (strlen($data) <= 12) {
+        if (\strlen($data) <= 12) {
             return null;
         }
 
         $offset      = 0;
-        $roffset     = self::unpack(self::BIT_B64, substr($data, $offset, 8));
+        $roffset     = self::unpack(self::BIT_B64, \substr($data, $offset, 8));
         $offset     += 8;
-        $messageSize = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $messageSize = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset     += 4;
-        $ret         = $this->decodeMessage(substr($data, $offset), $messageSize);
+        $ret         = $this->decodeMessage(\substr($data, $offset), $messageSize);
 
         if ($ret === null) {
             return null;
@@ -219,13 +219,13 @@ class Fetch extends Protocol
         }
 
         $offset  = 0;
-        $crc     = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $crc     = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset += 4;
 
-        $magic = self::unpack(self::BIT_B8, substr($data, $offset, 1));
+        $magic = self::unpack(self::BIT_B8, \substr($data, $offset, 1));
         ++$offset;
 
-        $attr = self::unpack(self::BIT_B8, substr($data, $offset, 1));
+        $attr = self::unpack(self::BIT_B8, \substr($data, $offset, 1));
         ++$offset;
 
         $timestamp  = 0;
@@ -233,14 +233,14 @@ class Fetch extends Protocol
 
         try { // try unpack message format v1, falling back to v0 if it fails
             if ($magic >= self::MESSAGE_MAGIC_VERSION1) {
-                $timestamp = self::unpack(self::BIT_B64, substr($data, $offset, 8));
+                $timestamp = self::unpack(self::BIT_B64, \substr($data, $offset, 8));
                 $offset   += 8;
             }
 
-            $keyRet  = $this->decodeString(substr($data, $offset), self::BIT_B32);
+            $keyRet  = $this->decodeString(\substr($data, $offset), self::BIT_B32);
             $offset += $keyRet['length'];
 
-            $valueRet = $this->decodeString((string) substr($data, $offset), self::BIT_B32, $attr & Produce::COMPRESSION_CODEC_MASK);
+            $valueRet = $this->decodeString((string) \substr($data, $offset), self::BIT_B32, $attr & Produce::COMPRESSION_CODEC_MASK);
             $offset  += $valueRet['length'];
 
             if ($offset !== $messageSize) {
@@ -251,10 +251,10 @@ class Fetch extends Protocol
         } catch (Exception $e) { // try unpack message format v0
             $offset    = $backOffset;
             $timestamp = 0;
-            $keyRet    = $this->decodeString(substr($data, $offset), self::BIT_B32);
+            $keyRet    = $this->decodeString(\substr($data, $offset), self::BIT_B32);
             $offset   += $keyRet['length'];
 
-            $valueRet = $this->decodeString(substr($data, $offset), self::BIT_B32);
+            $valueRet = $this->decodeString(\substr($data, $offset), self::BIT_B32);
             $offset  += $valueRet['length'];
         }
 

--- a/src/Protocol/FetchOffset.php
+++ b/src/Protocol/FetchOffset.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 

--- a/src/Protocol/FetchOffset.php
+++ b/src/Protocol/FetchOffset.php
@@ -38,7 +38,7 @@ class FetchOffset extends Protocol
     public function decode(string $data): array
     {
         $offset  = 0;
-        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'offsetTopic']);
+        $topics  = $this->decodeArray(\substr($data, $offset), [$this, 'offsetTopic']);
         $offset += $topics['length'];
 
         return $topics['data'];
@@ -78,10 +78,10 @@ class FetchOffset extends Protocol
     protected function offsetTopic(string $data): array
     {
         $offset    = 0;
-        $topicInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $topicInfo = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset   += $topicInfo['length'];
 
-        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'offsetPartition']);
+        $partitions = $this->decodeArray(\substr($data, $offset), [$this, 'offsetPartition']);
         $offset    += $partitions['length'];
 
         return [
@@ -101,15 +101,15 @@ class FetchOffset extends Protocol
     {
         $offset = 0;
 
-        $partitionId = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $partitionId = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset     += 4;
 
-        $roffset = self::unpack(self::BIT_B64, substr($data, $offset, 8));
+        $roffset = self::unpack(self::BIT_B64, \substr($data, $offset, 8));
         $offset += 8;
 
-        $metadata  = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $metadata  = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset   += $metadata['length'];
-        $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset   += 2;
 
         return [

--- a/src/Protocol/GroupCoordinator.php
+++ b/src/Protocol/GroupCoordinator.php
@@ -33,13 +33,13 @@ class GroupCoordinator extends Protocol
     public function decode(string $data): array
     {
         $offset          = 0;
-        $errorCode       = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode       = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset         += 2;
-        $coordinatorId   = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $coordinatorId   = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset         += 4;
-        $hosts           = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $hosts           = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset         += $hosts['length'];
-        $coordinatorPort = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $coordinatorPort = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset         += 4;
 
         return [

--- a/src/Protocol/GroupCoordinator.php
+++ b/src/Protocol/GroupCoordinator.php
@@ -1,12 +1,21 @@
 <?php
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class GroupCoordinator extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws ProtocolException
+     * @throws NotSupported
+     */
     public function encode(array $payloads = []): string
     {
         if (! isset($payloads['group_id'])) {
-            throw new \Kafka\Exception\Protocol('given group coordinator invalid. `group_id` is undefined.');
+            throw new ProtocolException('given group coordinator invalid. `group_id` is undefined.');
         }
 
         $header = $this->requestHeader('kafka-php', self::GROUP_COORDINATOR_REQUEST, self::GROUP_COORDINATOR_REQUEST);
@@ -16,6 +25,9 @@ class GroupCoordinator extends Protocol
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset          = 0;

--- a/src/Protocol/GroupCoordinator.php
+++ b/src/Protocol/GroupCoordinator.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Protocol;
 
 use Kafka\Exception\NotSupported;

--- a/src/Protocol/Heartbeat.php
+++ b/src/Protocol/Heartbeat.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 
@@ -29,7 +30,7 @@ class Heartbeat extends Protocol
 
         $header = $this->requestHeader('kafka-php', self::HEART_BEAT_REQUEST, self::HEART_BEAT_REQUEST);
         $data   = self::encodeString($payloads['group_id'], self::PACK_INT16);
-        $data  .= self::pack(self::BIT_B32, $payloads['generation_id']);
+        $data  .= self::pack(self::BIT_B32, (string) $payloads['generation_id']);
         $data  .= self::encodeString($payloads['member_id'], self::PACK_INT16);
 
         $data = self::encodeString($header . $data, self::PACK_INT32);

--- a/src/Protocol/Heartbeat.php
+++ b/src/Protocol/Heartbeat.php
@@ -44,7 +44,7 @@ class Heartbeat extends Protocol
     public function decode(string $data): array
     {
         $offset    = 0;
-        $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset   += 2;
 
         return ['errorCode' => $errorCode];

--- a/src/Protocol/Heartbeat.php
+++ b/src/Protocol/Heartbeat.php
@@ -47,8 +47,6 @@ class Heartbeat extends Protocol
         $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
         $offset   += 2;
 
-        return [
-            'errorCode' => $errorCode,
-        ];
+        return ['errorCode' => $errorCode];
     }
 }

--- a/src/Protocol/Heartbeat.php
+++ b/src/Protocol/Heartbeat.php
@@ -2,20 +2,29 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class Heartbeat extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     public function encode(array $payloads = []): string
     {
         if (! isset($payloads['group_id'])) {
-            throw new \Kafka\Exception\Protocol('given heartbeat data invalid. `group_id` is undefined.');
+            throw new ProtocolException('given heartbeat data invalid. `group_id` is undefined.');
         }
 
         if (! isset($payloads['generation_id'])) {
-            throw new \Kafka\Exception\Protocol('given heartbeat data invalid. `generation_id` is undefined.');
+            throw new ProtocolException('given heartbeat data invalid. `generation_id` is undefined.');
         }
 
         if (! isset($payloads['member_id'])) {
-            throw new \Kafka\Exception\Protocol('given heartbeat data invalid. `member_id` is undefined.');
+            throw new ProtocolException('given heartbeat data invalid. `member_id` is undefined.');
         }
 
         $header = $this->requestHeader('kafka-php', self::HEART_BEAT_REQUEST, self::HEART_BEAT_REQUEST);
@@ -28,6 +37,9 @@ class Heartbeat extends Protocol
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset    = 0;

--- a/src/Protocol/JoinGroup.php
+++ b/src/Protocol/JoinGroup.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 
@@ -41,10 +42,10 @@ class JoinGroup extends Protocol
 
         $header = $this->requestHeader('kafka-php', self::JOIN_GROUP_REQUEST, self::JOIN_GROUP_REQUEST);
         $data   = self::encodeString($payloads['group_id'], self::PACK_INT16);
-        $data  .= self::pack(self::BIT_B32, $payloads['session_timeout']);
+        $data  .= self::pack(self::BIT_B32, (string) $payloads['session_timeout']);
 
         if ($this->getApiVersion(self::JOIN_GROUP_REQUEST) === self::API_VERSION1) {
-            $data .= self::pack(self::BIT_B32, $payloads['rebalance_timeout']);
+            $data .= self::pack(self::BIT_B32, (string) $payloads['rebalance_timeout']);
         }
 
         $data .= self::encodeString($payloads['member_id'], self::PACK_INT16);

--- a/src/Protocol/JoinGroup.php
+++ b/src/Protocol/JoinGroup.php
@@ -2,24 +2,33 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class JoinGroup extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     public function encode(array $payloads = []): string
     {
         if (! isset($payloads['group_id'])) {
-            throw new \Kafka\Exception\Protocol('given join group data invalid. `group_id` is undefined.');
+            throw new ProtocolException('given join group data invalid. `group_id` is undefined.');
         }
 
         if (! isset($payloads['session_timeout'])) {
-            throw new \Kafka\Exception\Protocol('given join group data invalid. `session_timeout` is undefined.');
+            throw new ProtocolException('given join group data invalid. `session_timeout` is undefined.');
         }
 
         if (! isset($payloads['member_id'])) {
-            throw new \Kafka\Exception\Protocol('given join group data invalid. `member_id` is undefined.');
+            throw new ProtocolException('given join group data invalid. `member_id` is undefined.');
         }
 
         if (! isset($payloads['data'])) {
-            throw new \Kafka\Exception\Protocol('given join group data invalid. `data` is undefined.');
+            throw new ProtocolException('given join group data invalid. `data` is undefined.');
         }
 
         if (! isset($payloads['protocol_type'])) {
@@ -46,6 +55,9 @@ class JoinGroup extends Protocol
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset        = 0;
@@ -73,20 +85,26 @@ class JoinGroup extends Protocol
         ];
     }
 
+    /**
+     * @param mixed[] $values
+     *
+     * @throws ProtocolException
+     * @throws NotSupported
+     */
     protected function encodeGroupProtocol(array $values): string
     {
         if (! isset($values['protocol_name'])) {
-            throw new \Kafka\Exception\Protocol('given join group data invalid. `protocol_name` is undefined.');
+            throw new ProtocolException('given join group data invalid. `protocol_name` is undefined.');
         }
 
         $protocolName = self::encodeString($values['protocol_name'], self::PACK_INT16);
 
         if (! isset($values['version'])) {
-            throw new \Kafka\Exception\Protocol('given data invalid. `version` is undefined.');
+            throw new ProtocolException('given data invalid. `version` is undefined.');
         }
 
         if (! isset($values['subscription']) || empty($values['subscription'])) {
-            throw new \Kafka\Exception\Protocol('given data invalid. `subscription` is undefined.');
+            throw new ProtocolException('given data invalid. `subscription` is undefined.');
         }
         if (! isset($values['user_data'])) {
             $values['user_data'] = '';
@@ -99,11 +117,17 @@ class JoinGroup extends Protocol
         return $protocolName . self::encodeString($data, self::PACK_INT32);
     }
 
+    /**
+     * @throws NotSupported
+     */
     protected function encodeGroupProtocolMetaTopic(string $values): string
     {
         return self::encodeString($values, self::PACK_INT16);
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function joinGroupMember(string $data): array
     {
         $offset     = 0;

--- a/src/Protocol/JoinGroup.php
+++ b/src/Protocol/JoinGroup.php
@@ -62,18 +62,18 @@ class JoinGroup extends Protocol
     public function decode(string $data): array
     {
         $offset        = 0;
-        $errorCode     = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode     = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset       += 2;
-        $generationId  = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $generationId  = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset       += 4;
-        $groupProtocol = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $groupProtocol = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset       += $groupProtocol['length'];
-        $leaderId      = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $leaderId      = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset       += $leaderId['length'];
-        $memberId      = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $memberId      = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset       += $memberId['length'];
 
-        $members = $this->decodeArray(substr($data, $offset), [$this, 'joinGroupMember']);
+        $members = $this->decodeArray(\substr($data, $offset), [$this, 'joinGroupMember']);
         $offset += $memberId['length'];
 
         return [
@@ -132,18 +132,18 @@ class JoinGroup extends Protocol
     protected function joinGroupMember(string $data): array
     {
         $offset     = 0;
-        $memberId   = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $memberId   = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset    += $memberId['length'];
-        $memberMeta = $this->decodeString(substr($data, $offset), self::BIT_B32);
+        $memberMeta = $this->decodeString(\substr($data, $offset), self::BIT_B32);
         $offset    += $memberMeta['length'];
 
         $metaData    = $memberMeta['data'];
         $metaOffset  = 0;
-        $version     = self::unpack(self::BIT_B16, substr($metaData, $metaOffset, 2));
+        $version     = self::unpack(self::BIT_B16, \substr($metaData, $metaOffset, 2));
         $metaOffset += 2;
-        $topics      = $this->decodeArray(substr($metaData, $metaOffset), [$this, 'decodeString'], self::BIT_B16);
+        $topics      = $this->decodeArray(\substr($metaData, $metaOffset), [$this, 'decodeString'], self::BIT_B16);
         $metaOffset += $topics['length'];
-        $userData    = $this->decodeString(substr($metaData, $metaOffset), self::BIT_B32);
+        $userData    = $this->decodeString(\substr($metaData, $metaOffset), self::BIT_B32);
 
         return [
             'length' => $offset,

--- a/src/Protocol/LeaveGroup.php
+++ b/src/Protocol/LeaveGroup.php
@@ -36,7 +36,7 @@ class LeaveGroup extends Protocol
      */
     public function decode(string $data): array
     {
-        $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, 0, 2));
+        $errorCode = self::unpack(self::BIT_B16_SIGNED, \substr($data, 0, 2));
 
         return ['errorCode' => $errorCode];
     }

--- a/src/Protocol/LeaveGroup.php
+++ b/src/Protocol/LeaveGroup.php
@@ -2,33 +2,41 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class LeaveGroup extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     public function encode(array $payloads = []): string
     {
         if (! isset($payloads['group_id'])) {
-            throw new \Kafka\Exception\Protocol('given leave group data invalid. `group_id` is undefined.');
+            throw new ProtocolException('given leave group data invalid. `group_id` is undefined.');
         }
 
         if (! isset($payloads['member_id'])) {
-            throw new \Kafka\Exception\Protocol('given leave group data invalid. `member_id` is undefined.');
+            throw new ProtocolException('given leave group data invalid. `member_id` is undefined.');
         }
 
         $header = $this->requestHeader('kafka-php', self::LEAVE_GROUP_REQUEST, self::LEAVE_GROUP_REQUEST);
         $data   = self::encodeString($payloads['group_id'], self::PACK_INT16);
         $data  .= self::encodeString($payloads['member_id'], self::PACK_INT16);
 
-        $data = self::encodeString($header . $data, self::PACK_INT32);
-
-        return $data;
+        return self::encodeString($header . $data, self::PACK_INT32);
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, 0, 2));
 
-        return [
-            'errorCode' => $errorCode,
-        ];
+        return ['errorCode' => $errorCode];
     }
 }

--- a/src/Protocol/LeaveGroup.php
+++ b/src/Protocol/LeaveGroup.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 

--- a/src/Protocol/ListGroup.php
+++ b/src/Protocol/ListGroup.php
@@ -25,9 +25,9 @@ class ListGroup extends Protocol
     public function decode(string $data): array
     {
         $offset    = 0;
-        $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset   += 2;
-        $groups    = $this->decodeArray(substr($data, $offset), [$this, 'listGroup']);
+        $groups    = $this->decodeArray(\substr($data, $offset), [$this, 'listGroup']);
 
         return [
             'errorCode' => $errorCode,
@@ -41,9 +41,9 @@ class ListGroup extends Protocol
     protected function listGroup(string $data): array
     {
         $offset       = 0;
-        $groupId      = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $groupId      = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset      += $groupId['length'];
-        $protocolType = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $protocolType = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset      += $protocolType['length'];
 
         return [

--- a/src/Protocol/ListGroup.php
+++ b/src/Protocol/ListGroup.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 

--- a/src/Protocol/ListGroup.php
+++ b/src/Protocol/ListGroup.php
@@ -2,8 +2,15 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+
 class ListGroup extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     */
     public function encode(array $payloads = []): string
     {
         $header = $this->requestHeader('kafka-php', self::LIST_GROUPS_REQUEST, self::LIST_GROUPS_REQUEST);
@@ -11,6 +18,9 @@ class ListGroup extends Protocol
         return self::encodeString($header, self::PACK_INT32);
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset    = 0;
@@ -24,6 +34,9 @@ class ListGroup extends Protocol
         ];
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function listGroup(string $data): array
     {
         $offset       = 0;

--- a/src/Protocol/Metadata.php
+++ b/src/Protocol/Metadata.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 

--- a/src/Protocol/Metadata.php
+++ b/src/Protocol/Metadata.php
@@ -35,9 +35,9 @@ class Metadata extends Protocol
     public function decode(string $data): array
     {
         $offset       = 0;
-        $brokerRet    = $this->decodeArray(substr($data, $offset), [$this, 'metaBroker']);
+        $brokerRet    = $this->decodeArray(\substr($data, $offset), [$this, 'metaBroker']);
         $offset      += $brokerRet['length'];
-        $topicMetaRet = $this->decodeArray(substr($data, $offset), [$this, 'metaTopicMetaData']);
+        $topicMetaRet = $this->decodeArray(\substr($data, $offset), [$this, 'metaTopicMetaData']);
         $offset      += $topicMetaRet['length'];
 
         $result = [
@@ -54,11 +54,11 @@ class Metadata extends Protocol
     protected function metaBroker(string $data): array
     {
         $offset       = 0;
-        $nodeId       = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $nodeId       = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset      += 4;
-        $hostNameInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $hostNameInfo = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset      += $hostNameInfo['length'];
-        $port         = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $port         = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset      += 4;
 
         return [
@@ -77,11 +77,11 @@ class Metadata extends Protocol
     protected function metaTopicMetaData(string $data): array
     {
         $offset         = 0;
-        $topicErrCode   = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $topicErrCode   = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset        += 2;
-        $topicInfo      = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $topicInfo      = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset        += $topicInfo['length'];
-        $partitionsMeta = $this->decodeArray(substr($data, $offset), [$this, 'metaPartitionMetaData']);
+        $partitionsMeta = $this->decodeArray(\substr($data, $offset), [$this, 'metaPartitionMetaData']);
         $offset        += $partitionsMeta['length'];
 
         return [
@@ -100,15 +100,15 @@ class Metadata extends Protocol
     protected function metaPartitionMetaData(string $data): array
     {
         $offset   = 0;
-        $errcode  = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errcode  = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset  += 2;
-        $partId   = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $partId   = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset  += 4;
-        $leader   = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $leader   = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset  += 4;
-        $replicas = $this->decodePrimitiveArray(substr($data, $offset), self::BIT_B32);
+        $replicas = $this->decodePrimitiveArray(\substr($data, $offset), self::BIT_B32);
         $offset  += $replicas['length'];
-        $isr      = $this->decodePrimitiveArray(substr($data, $offset), self::BIT_B32);
+        $isr      = $this->decodePrimitiveArray(\substr($data, $offset), self::BIT_B32);
         $offset  += $isr['length'];
 
         return [

--- a/src/Protocol/Metadata.php
+++ b/src/Protocol/Metadata.php
@@ -2,13 +2,22 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class Metadata extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     public function encode(array $payloads = []): string
     {
         foreach ($payloads as $topic) {
             if (! \is_string($topic)) {
-                throw new \Kafka\Exception\Protocol('request metadata topic array have invalid value. ');
+                throw new ProtocolException('request metadata topic array have invalid value. ');
             }
         }
 
@@ -19,13 +28,15 @@ class Metadata extends Protocol
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset       = 0;
-        $version      = $this->getApiVersion(self::METADATA_REQUEST);
-        $brokerRet    = $this->decodeArray(substr($data, $offset), [$this, 'metaBroker'], $version);
+        $brokerRet    = $this->decodeArray(substr($data, $offset), [$this, 'metaBroker']);
         $offset      += $brokerRet['length'];
-        $topicMetaRet = $this->decodeArray(substr($data, $offset), [$this, 'metaTopicMetaData'], $version);
+        $topicMetaRet = $this->decodeArray(substr($data, $offset), [$this, 'metaTopicMetaData']);
         $offset      += $topicMetaRet['length'];
 
         $result = [
@@ -36,7 +47,10 @@ class Metadata extends Protocol
         return $result;
     }
 
-    protected function metaBroker(string $data, string $version): array
+    /**
+     * @return mixed[]
+     */
+    protected function metaBroker(string $data): array
     {
         $offset       = 0;
         $nodeId       = self::unpack(self::BIT_B32, substr($data, $offset, 4));
@@ -56,14 +70,17 @@ class Metadata extends Protocol
         ];
     }
 
-    protected function metaTopicMetaData(string $data, string $version): array
+    /**
+     * @return mixed[]
+     */
+    protected function metaTopicMetaData(string $data): array
     {
         $offset         = 0;
         $topicErrCode   = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
         $offset        += 2;
         $topicInfo      = $this->decodeString(substr($data, $offset), self::BIT_B16);
         $offset        += $topicInfo['length'];
-        $partitionsMeta = $this->decodeArray(substr($data, $offset), [$this, 'metaPartitionMetaData'], $version);
+        $partitionsMeta = $this->decodeArray(substr($data, $offset), [$this, 'metaPartitionMetaData']);
         $offset        += $partitionsMeta['length'];
 
         return [
@@ -76,7 +93,10 @@ class Metadata extends Protocol
         ];
     }
 
-    protected function metaPartitionMetaData(string $data, string $version): array
+    /**
+     * @return mixed[]
+     */
+    protected function metaPartitionMetaData(string $data): array
     {
         $offset   = 0;
         $errcode  = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));

--- a/src/Protocol/Offset.php
+++ b/src/Protocol/Offset.php
@@ -36,7 +36,7 @@ class Offset extends Protocol
         $offset = 0;
 
         $version = $this->getApiVersion(self::OFFSET_REQUEST);
-        $topics  = $this->decodeArray(substr($data, $offset), [$this, 'offsetTopic'], $version);
+        $topics  = $this->decodeArray(\substr($data, $offset), [$this, 'offsetTopic'], $version);
         $offset += $topics['length'];
 
         return $topics['data'];
@@ -94,10 +94,10 @@ class Offset extends Protocol
     protected function offsetTopic(string $data, int $version): array
     {
         $offset    = 0;
-        $topicInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $topicInfo = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset   += $topicInfo['length'];
 
-        $partitions = $this->decodeArray(substr($data, $offset), [$this, 'offsetPartition'], $version);
+        $partitions = $this->decodeArray(\substr($data, $offset), [$this, 'offsetPartition'], $version);
         $offset    += $partitions['length'];
 
         return [
@@ -115,18 +115,18 @@ class Offset extends Protocol
     protected function offsetPartition(string $data, int $version): array
     {
         $offset      = 0;
-        $partitionId = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $partitionId = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset     += 4;
-        $errorCode   = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode   = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset     += 2;
         $timestamp   = 0;
 
         if ($version !== self::API_VERSION0) {
-            $timestamp = self::unpack(self::BIT_B64, substr($data, $offset, 8));
+            $timestamp = self::unpack(self::BIT_B64, \substr($data, $offset, 8));
             $offset   += 8;
         }
 
-        $offsets = $this->decodePrimitiveArray(substr($data, $offset), self::BIT_B64);
+        $offsets = $this->decodePrimitiveArray(\substr($data, $offset), self::BIT_B64);
         $offset += $offsets['length'];
 
         return [

--- a/src/Protocol/Offset.php
+++ b/src/Protocol/Offset.php
@@ -2,12 +2,17 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\Protocol as ProtocolException;
+
 class Offset extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     */
     public function encode(array $payloads = []): string
     {
         if (! isset($payloads['data'])) {
-            throw new \Kafka\Exception\Protocol('given offset data invalid. `data` is undefined.');
+            throw new ProtocolException('given offset data invalid. `data` is undefined.');
         }
 
         if (! isset($payloads['replica_id'])) {
@@ -22,6 +27,9 @@ class Offset extends Protocol
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset = 0;
@@ -33,10 +41,13 @@ class Offset extends Protocol
         return $topics['data'];
     }
 
+    /**
+     * @param mixed[] $values
+     */
     protected function encodeOffsetPartition(array $values): string
     {
         if (! isset($values['partition_id'])) {
-            throw new \Kafka\Exception\Protocol('given offset data invalid. `partition_id` is undefined.');
+            throw new ProtocolException('given offset data invalid. `partition_id` is undefined.');
         }
 
         if (! isset($values['time'])) {
@@ -57,14 +68,17 @@ class Offset extends Protocol
         return $data;
     }
 
+    /**
+     * @param mixed[] $values
+     */
     protected function encodeOffsetTopic(array $values): string
     {
         if (! isset($values['topic_name'])) {
-            throw new \Kafka\Exception\Protocol('given offset data invalid. `topic_name` is undefined.');
+            throw new ProtocolException('given offset data invalid. `topic_name` is undefined.');
         }
 
         if (! isset($values['partitions']) || empty($values['partitions'])) {
-            throw new \Kafka\Exception\Protocol('given offset data invalid. `partitions` is undefined.');
+            throw new ProtocolException('given offset data invalid. `partitions` is undefined.');
         }
 
         $topic      = self::encodeString($values['topic_name'], self::PACK_INT16);
@@ -73,6 +87,9 @@ class Offset extends Protocol
         return $topic . $partitions;
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function offsetTopic(string $data, int $version): array
     {
         $offset    = 0;
@@ -91,6 +108,9 @@ class Offset extends Protocol
         ];
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function offsetPartition(string $data, int $version): array
     {
         $offset      = 0;

--- a/src/Protocol/Offset.php
+++ b/src/Protocol/Offset.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 
@@ -20,7 +21,7 @@ class Offset extends Protocol
         }
 
         $header = $this->requestHeader('kafka-php', self::OFFSET_REQUEST, self::OFFSET_REQUEST);
-        $data   = self::pack(self::BIT_B32, $payloads['replica_id']);
+        $data   = self::pack(self::BIT_B32, (string) $payloads['replica_id']);
         $data  .= self::encodeArray($payloads['data'], [$this, 'encodeOffsetTopic']);
         $data   = self::encodeString($header . $data, self::PACK_INT32);
 
@@ -58,11 +59,11 @@ class Offset extends Protocol
             $values['max_offset'] = 100000;
         }
 
-        $data  = self::pack(self::BIT_B32, $values['partition_id']);
-        $data .= self::pack(self::BIT_B64, $values['time']);
+        $data  = self::pack(self::BIT_B32, (string) $values['partition_id']);
+        $data .= self::pack(self::BIT_B64, (string) $values['time']);
 
         if ($this->getApiVersion(self::OFFSET_REQUEST) === self::API_VERSION0) {
-            $data .= self::pack(self::BIT_B32, $values['max_offset']);
+            $data .= self::pack(self::BIT_B32, (string) $values['max_offset']);
         }
 
         return $data;

--- a/src/Protocol/Offset.php
+++ b/src/Protocol/Offset.php
@@ -73,7 +73,7 @@ class Offset extends Protocol
         return $topic . $partitions;
     }
 
-    protected function offsetTopic(string $data, string $version): array
+    protected function offsetTopic(string $data, int $version): array
     {
         $offset    = 0;
         $topicInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
@@ -91,7 +91,7 @@ class Offset extends Protocol
         ];
     }
 
-    protected function offsetPartition(string $data, string $version): array
+    protected function offsetPartition(string $data, int $version): array
     {
         $offset      = 0;
         $partitionId = self::unpack(self::BIT_B32, substr($data, $offset, 4));
@@ -99,10 +99,12 @@ class Offset extends Protocol
         $errorCode   = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
         $offset     += 2;
         $timestamp   = 0;
-        if ($version != self::API_VERSION0) {
+
+        if ($version !== self::API_VERSION0) {
             $timestamp = self::unpack(self::BIT_B64, substr($data, $offset, 8));
             $offset   += 8;
         }
+
         $offsets = $this->decodePrimitiveArray(substr($data, $offset), self::BIT_B64);
         $offset += $offsets['length'];
 

--- a/src/Protocol/Produce.php
+++ b/src/Protocol/Produce.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 
@@ -49,8 +50,8 @@ class Produce extends Protocol
         }
 
         $header = $this->requestHeader('kafka-php', 0, self::PRODUCE_REQUEST);
-        $data   = self::pack(self::BIT_B16, $payloads['required_ack'] ?? 0);
-        $data  .= self::pack(self::BIT_B32, $payloads['timeout'] ?? 100);
+        $data   = self::pack(self::BIT_B16, (string) ($payloads['required_ack'] ?? 0));
+        $data  .= self::pack(self::BIT_B32, (string) ($payloads['timeout'] ?? 100));
         $data  .= self::encodeArray(
             $payloads['data'],
             [$this, 'encodeProduceTopic'],
@@ -141,7 +142,7 @@ class Produce extends Protocol
         // message value
         $data .= self::encodeString($message, self::PACK_INT32, $compression);
 
-        $crc = crc32($data);
+        $crc = (string) crc32($data);
 
         // int32 -- crc code  string data
         $message = self::pack(self::BIT_B32, $crc) . $data;
@@ -204,7 +205,7 @@ class Produce extends Protocol
             throw new ProtocolException('given produce data invalid. `messages` is undefined.');
         }
 
-        $data  = self::pack(self::BIT_B32, $values['partition_id']);
+        $data  = self::pack(self::BIT_B32, (string) $values['partition_id']);
         $data .= self::encodeString(
             $this->encodeMessageSet((array) $values['messages'], $compression),
             self::PACK_INT32

--- a/src/Protocol/Produce.php
+++ b/src/Protocol/Produce.php
@@ -70,12 +70,12 @@ class Produce extends Protocol
     {
         $offset       = 0;
         $version      = $this->getApiVersion(self::PRODUCE_REQUEST);
-        $ret          = $this->decodeArray(substr($data, $offset), [$this, 'produceTopicPair'], $version);
+        $ret          = $this->decodeArray(\substr($data, $offset), [$this, 'produceTopicPair'], $version);
         $offset      += $ret['length'];
         $throttleTime = 0;
 
         if ($version === self::API_VERSION2) {
-            $throttleTime = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+            $throttleTime = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         }
 
         return ['throttleTime' => $throttleTime, 'data' => $ret['data']];
@@ -131,7 +131,7 @@ class Produce extends Protocol
 
         $key = '';
 
-        if (is_array($message)) {
+        if (\is_array($message)) {
             $key     = $message['key'];
             $message = $message['value'];
         }
@@ -142,7 +142,7 @@ class Produce extends Protocol
         // message value
         $data .= self::encodeString($message, self::PACK_INT32, $compression);
 
-        $crc = (string) crc32($data);
+        $crc = (string) \crc32($data);
 
         // int32 -- crc code  string data
         $message = self::pack(self::BIT_B32, $crc) . $data;
@@ -250,7 +250,7 @@ class Produce extends Protocol
         $offset    = 0;
         $topicInfo = $this->decodeString($data, self::BIT_B16);
         $offset   += $topicInfo['length'];
-        $ret       = $this->decodeArray(substr($data, $offset), [$this, 'producePartitionPair'], $version);
+        $ret       = $this->decodeArray(\substr($data, $offset), [$this, 'producePartitionPair'], $version);
         $offset   += $ret['length'];
 
         return [
@@ -272,16 +272,16 @@ class Produce extends Protocol
     protected function producePartitionPair(string $data, int $version): array
     {
         $offset          = 0;
-        $partitionId     = self::unpack(self::BIT_B32, substr($data, $offset, 4));
+        $partitionId     = self::unpack(self::BIT_B32, \substr($data, $offset, 4));
         $offset         += 4;
-        $errorCode       = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode       = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset         += 2;
-        $partitionOffset = self::unpack(self::BIT_B64, substr($data, $offset, 8));
+        $partitionOffset = self::unpack(self::BIT_B64, \substr($data, $offset, 8));
         $offset         += 8;
         $timestamp       = 0;
 
         if ($version === self::API_VERSION2) {
-            $timestamp = self::unpack(self::BIT_B64, substr($data, $offset, 8));
+            $timestamp = self::unpack(self::BIT_B64, \substr($data, $offset, 8));
             $offset   += 8;
         }
 

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 
@@ -397,7 +398,7 @@ abstract class Protocol
         $packLen = $bytes === self::PACK_INT32 ? self::BIT_B32 : self::BIT_B16;
         $string  = self::compress($string, $compression);
 
-        return self::pack($packLen, \strlen($string)) . $string;
+        return self::pack($packLen, (string) \strlen($string)) . $string;
     }
 
     private static function compress(string $string, int $compression): string

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -2,10 +2,10 @@
 
 namespace Kafka\Protocol;
 
-use Kafka\Exception\Protocol as ProtocolException;
-use Psr\Log\LoggerAwareTrait;
-use Kafka\LoggerTrait;
 use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+use Kafka\LoggerTrait;
+use Psr\Log\LoggerAwareTrait;
 
 abstract class Protocol
 {

--- a/src/Protocol/Protocol.php
+++ b/src/Protocol/Protocol.php
@@ -3,11 +3,14 @@
 namespace Kafka\Protocol;
 
 use Kafka\Exception\Protocol as ProtocolException;
+use Psr\Log\LoggerAwareTrait;
+use Kafka\LoggerTrait;
+use Kafka\Exception\NotSupported;
 
 abstract class Protocol
 {
-    use \Psr\Log\LoggerAwareTrait;
-    use \Kafka\LoggerTrait;
+    use LoggerAwareTrait;
+    use LoggerTrait;
 
     /**
      *  Default kafka broker verion
@@ -407,7 +410,7 @@ abstract class Protocol
         }
 
         if ($compression === self::COMPRESSION_SNAPPY) {
-            throw new \Kafka\Exception\NotSupported('SNAPPY compression not yet implemented');
+            throw new NotSupported('SNAPPY compression not yet implemented');
         }
 
         if ($compression !== self::COMPRESSION_GZIP) {

--- a/src/Protocol/SaslHandShake.php
+++ b/src/Protocol/SaslHandShake.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 

--- a/src/Protocol/SaslHandShake.php
+++ b/src/Protocol/SaslHandShake.php
@@ -23,7 +23,7 @@ class SaslHandShake extends Protocol
      */
     public function encode(array $payloads = []): string
     {
-        $mechanism = array_shift($payloads);
+        $mechanism = \array_shift($payloads);
 
         if (! \is_string($mechanism)) {
             throw new ProtocolException('Invalid request SASL hand shake mechanism given. ');
@@ -31,7 +31,7 @@ class SaslHandShake extends Protocol
 
         if (! \in_array($mechanism, self::ALLOW_SASL_MECHANISMS, true)) {
             throw new ProtocolException(
-                'Invalid request SASL hand shake mechanism given, it must be one of: ' . implode('|', self::ALLOW_SASL_MECHANISMS)
+                'Invalid request SASL hand shake mechanism given, it must be one of: ' . \implode('|', self::ALLOW_SASL_MECHANISMS)
             );
         }
 
@@ -48,9 +48,9 @@ class SaslHandShake extends Protocol
     public function decode(string $data): array
     {
         $offset            = 0;
-        $errcode           = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errcode           = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset           += 2;
-        $enabledMechanisms = $this->decodeArray(substr($data, $offset), [$this, 'mechanism']);
+        $enabledMechanisms = $this->decodeArray(\substr($data, $offset), [$this, 'mechanism']);
         $offset           += $enabledMechanisms['length'];
 
         return [
@@ -65,7 +65,7 @@ class SaslHandShake extends Protocol
     protected function mechanism(string $data): array
     {
         $offset        = 0;
-        $mechanismInfo = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $mechanismInfo = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset       += $mechanismInfo['length'];
 
         return [

--- a/src/Protocol/SaslHandShake.php
+++ b/src/Protocol/SaslHandShake.php
@@ -2,6 +2,9 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class SaslHandShake extends Protocol
 {
     private const ALLOW_SASL_MECHANISMS = [
@@ -11,16 +14,22 @@ class SaslHandShake extends Protocol
         'SCRAM-SHA-512',
     ];
 
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     public function encode(array $payloads = []): string
     {
         $mechanism = array_shift($payloads);
 
         if (! \is_string($mechanism)) {
-            throw new \Kafka\Exception\Protocol('Invalid request SASL hand shake mechanism given. ');
+            throw new ProtocolException('Invalid request SASL hand shake mechanism given. ');
         }
 
         if (! \in_array($mechanism, self::ALLOW_SASL_MECHANISMS, true)) {
-            throw new \Kafka\Exception\Protocol(
+            throw new ProtocolException(
                 'Invalid request SASL hand shake mechanism given, it must be one of: ' . implode('|', self::ALLOW_SASL_MECHANISMS)
             );
         }
@@ -32,6 +41,9 @@ class SaslHandShake extends Protocol
         return $data;
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset            = 0;
@@ -46,6 +58,9 @@ class SaslHandShake extends Protocol
         ];
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function mechanism(string $data): array
     {
         $offset        = 0;

--- a/src/Protocol/SyncGroup.php
+++ b/src/Protocol/SyncGroup.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Protocol;
 
@@ -33,7 +34,7 @@ class SyncGroup extends Protocol
 
         $header = $this->requestHeader('kafka-php', self::SYNC_GROUP_REQUEST, self::SYNC_GROUP_REQUEST);
         $data   = self::encodeString($payloads['group_id'], self::PACK_INT16);
-        $data  .= self::pack(self::BIT_B32, $payloads['generation_id']);
+        $data  .= self::pack(self::BIT_B32, (string) $payloads['generation_id']);
         $data  .= self::encodeString($payloads['member_id'], self::PACK_INT16);
         $data  .= self::encodeArray($payloads['data'], [$this, 'encodeGroupAssignment']);
 

--- a/src/Protocol/SyncGroup.php
+++ b/src/Protocol/SyncGroup.php
@@ -56,9 +56,7 @@ class SyncGroup extends Protocol
         $memberAssignment = $memberAssignments['data'];
 
         if ($memberAssignment === '') {
-            return [
-                'errorCode' => $errorCode,
-            ];
+            return ['errorCode' => $errorCode];
         }
 
         $memberAssignmentOffset  = 0;

--- a/src/Protocol/SyncGroup.php
+++ b/src/Protocol/SyncGroup.php
@@ -47,10 +47,10 @@ class SyncGroup extends Protocol
     public function decode(string $data): array
     {
         $offset    = 0;
-        $errorCode = self::unpack(self::BIT_B16_SIGNED, substr($data, $offset, 2));
+        $errorCode = self::unpack(self::BIT_B16_SIGNED, \substr($data, $offset, 2));
         $offset   += 2;
 
-        $memberAssignments = $this->decodeString(substr($data, $offset), self::BIT_B32);
+        $memberAssignments = $this->decodeString(\substr($data, $offset), self::BIT_B32);
         $offset           += $memberAssignments['length'];
 
         $memberAssignment = $memberAssignments['data'];
@@ -62,16 +62,16 @@ class SyncGroup extends Protocol
         $memberAssignmentOffset  = 0;
         $version                 = self::unpack(
             self::BIT_B16_SIGNED,
-            substr($memberAssignment, $memberAssignmentOffset, 2)
+            \substr($memberAssignment, $memberAssignmentOffset, 2)
         );
         $memberAssignmentOffset += 2;
         $partitionAssignments    = $this->decodeArray(
-            substr($memberAssignment, $memberAssignmentOffset),
+            \substr($memberAssignment, $memberAssignmentOffset),
             [$this, 'syncGroupResponsePartition']
         );
         $memberAssignmentOffset += $partitionAssignments['length'];
         $userData                = $this->decodeString(
-            substr($memberAssignment, $memberAssignmentOffset),
+            \substr($memberAssignment, $memberAssignmentOffset),
             self::BIT_B32
         );
 
@@ -149,9 +149,9 @@ class SyncGroup extends Protocol
     protected function syncGroupResponsePartition(string $data): array
     {
         $offset     = 0;
-        $topicName  = $this->decodeString(substr($data, $offset), self::BIT_B16);
+        $topicName  = $this->decodeString(\substr($data, $offset), self::BIT_B16);
         $offset    += $topicName['length'];
-        $partitions = $this->decodePrimitiveArray(substr($data, $offset), self::BIT_B32);
+        $partitions = $this->decodePrimitiveArray(\substr($data, $offset), self::BIT_B32);
         $offset    += $partitions['length'];
 
         return [

--- a/src/Protocol/SyncGroup.php
+++ b/src/Protocol/SyncGroup.php
@@ -2,24 +2,33 @@
 
 namespace Kafka\Protocol;
 
+use Kafka\Exception\NotSupported;
+use Kafka\Exception\Protocol as ProtocolException;
+
 class SyncGroup extends Protocol
 {
+    /**
+     * @param mixed[] $payloads
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     public function encode(array $payloads = []): string
     {
         if (! isset($payloads['group_id'])) {
-            throw new \Kafka\Exception\Protocol('given sync group data invalid. `group_id` is undefined.');
+            throw new ProtocolException('given sync group data invalid. `group_id` is undefined.');
         }
 
         if (! isset($payloads['generation_id'])) {
-            throw new \Kafka\Exception\Protocol('given sync group data invalid. `generation_id` is undefined.');
+            throw new ProtocolException('given sync group data invalid. `generation_id` is undefined.');
         }
 
         if (! isset($payloads['member_id'])) {
-            throw new \Kafka\Exception\Protocol('given sync group data invalid. `member_id` is undefined.');
+            throw new ProtocolException('given sync group data invalid. `member_id` is undefined.');
         }
 
         if (! isset($payloads['data'])) {
-            throw new \Kafka\Exception\Protocol('given sync group data invalid. `data` is undefined.');
+            throw new ProtocolException('given sync group data invalid. `data` is undefined.');
         }
 
         $header = $this->requestHeader('kafka-php', self::SYNC_GROUP_REQUEST, self::SYNC_GROUP_REQUEST);
@@ -31,6 +40,9 @@ class SyncGroup extends Protocol
         return self::encodeString($header . $data, self::PACK_INT32);
     }
 
+    /**
+     * @return mixed[]
+     */
     public function decode(string $data): array
     {
         $offset    = 0;
@@ -42,7 +54,7 @@ class SyncGroup extends Protocol
 
         $memberAssignment = $memberAssignments['data'];
 
-        if (! \strlen($memberAssignment)) {
+        if ($memberAssignment === '') {
             return [
                 'errorCode' => $errorCode,
             ];
@@ -72,18 +84,24 @@ class SyncGroup extends Protocol
         ];
     }
 
+    /**
+     * @param mixed[] $values
+     *
+     * @throws NotSupported
+     * @throws ProtocolException
+     */
     protected function encodeGroupAssignment(array $values): string
     {
         if (! isset($values['version'])) {
-            throw new \Kafka\Exception\Protocol('given data invalid. `version` is undefined.');
+            throw new ProtocolException('given data invalid. `version` is undefined.');
         }
 
         if (! isset($values['member_id'])) {
-            throw new \Kafka\Exception\Protocol('given data invalid. `member_id` is undefined.');
+            throw new ProtocolException('given data invalid. `member_id` is undefined.');
         }
 
         if (! isset($values['assignments'])) {
-            throw new \Kafka\Exception\Protocol('given data invalid. `assignments` is undefined.');
+            throw new ProtocolException('given data invalid. `assignments` is undefined.');
         }
 
         if (! isset($values['user_data'])) {
@@ -99,14 +117,20 @@ class SyncGroup extends Protocol
         return $memberId . self::encodeString($data, self::PACK_INT32);
     }
 
+    /**
+     * @param mixed[] $values
+     *
+     * @throws ProtocolException
+     * @throws NotSupported
+     */
     protected function encodeGroupAssignmentTopic(array $values): string
     {
         if (! isset($values['topic_name'])) {
-            throw new \Kafka\Exception\Protocol('given data invalid. `topic_name` is undefined.');
+            throw new ProtocolException('given data invalid. `topic_name` is undefined.');
         }
 
         if (! isset($values['partitions'])) {
-            throw new \Kafka\Exception\Protocol('given data invalid. `partitions` is undefined.');
+            throw new ProtocolException('given data invalid. `partitions` is undefined.');
         }
 
         $topicName  = self::encodeString($values['topic_name'], self::PACK_INT16);
@@ -120,6 +144,9 @@ class SyncGroup extends Protocol
         return self::pack(self::BIT_B32, (string) $values);
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function syncGroupResponsePartition(string $data): array
     {
         $offset     = 0;

--- a/src/Sasl/Gssapi.php
+++ b/src/Sasl/Gssapi.php
@@ -11,7 +11,7 @@ use KRB5CCache;
 
 class Gssapi extends Mechanism
 {
-    private const MECHANISM_NAME = "GSSAPI";
+    private const MECHANISM_NAME = 'GSSAPI';
 
     /**
      * @var string

--- a/src/Sasl/Gssapi.php
+++ b/src/Sasl/Gssapi.php
@@ -36,15 +36,15 @@ class Gssapi extends Mechanism
 
     public static function fromKeytab(string $keytab, string $principal): self
     {
-        if (! extension_loaded('krb5')) {
+        if (! \extension_loaded('krb5')) {
             throw new Exception('Extension "krb5" is required for "GSSAPI" authentication');
         }
 
-        if (! file_exists($keytab) || ! is_file($keytab)) {
+        if (! \file_exists($keytab) || ! \is_file($keytab)) {
             throw new Exception('Invalid keytab, keytab file not exists.');
         }
 
-        if (! is_readable($keytab)) {
+        if (! \is_readable($keytab)) {
             throw new Exception('Invalid keytab, keytab file disable read.');
         }
 

--- a/src/Sasl/Gssapi.php
+++ b/src/Sasl/Gssapi.php
@@ -49,7 +49,7 @@ class Gssapi extends Mechanism
      * @throws \Kafka\Exception\NotSupported
      * @throws \Kafka\Exception
      */
-    protected function performAuthentication(CommonSocket $socket) : void
+    protected function performAuthentication(CommonSocket $socket): void
     {
         $token = $this->initSecurityContext();
 
@@ -75,12 +75,12 @@ class Gssapi extends Mechanism
      * @access public
      * @return string
      */
-    public function getName() : string
+    public function getName(): string
     {
         return self::MECHANISM_NAME;
     }
 
-    private function initSecurityContext() : string
+    private function initSecurityContext(): string
     {
         $token = '';
         $ret   = $this->gssapi->initSecContext($this->principal, null, null, null, $token);
@@ -90,7 +90,7 @@ class Gssapi extends Mechanism
         return $token;
     }
 
-    private function wrapToken(string $token) : string
+    private function wrapToken(string $token): string
     {
         $message = '';
         $this->gssapi->wrap($token, $message);

--- a/src/Sasl/Gssapi.php
+++ b/src/Sasl/Gssapi.php
@@ -1,23 +1,32 @@
 <?php
 namespace Kafka\Sasl;
 
+use GSSAPIContext;
 use Kafka\CommonSocket;
-use Kafka\SaslMechanism;
 use Kafka\Exception;
-use Kafka\Protocol;
 use Kafka\Protocol\Protocol as ProtocolTool;
+use KRB5CCache;
 
 class Gssapi extends Mechanism
 {
     private const MECHANISM_NAME = "GSSAPI";
 
+    /**
+     * @var string
+     */
     private $principal;
 
+    /**
+     * @var GSSAPIContext
+     */
     private $gssapi;
 
+    /**
+     * @var KRB5CCache
+     */
     private static $ccache;
 
-    public function __construct(\GSSAPIContext $gssapi, string $principal)
+    public function __construct(GSSAPIContext $gssapi, string $principal)
     {
         $this->gssapi    = $gssapi;
         $this->principal = $principal;
@@ -37,10 +46,10 @@ class Gssapi extends Mechanism
             throw new Exception('Invalid keytab, keytab file disable read.');
         }
 
-        self::$ccache = new \KRB5CCache();
+        self::$ccache = new KRB5CCache();
         self::$ccache->initKeytab($principal, $keytab);
 
-        $gssapi = new \GSSAPIContext();
+        $gssapi = new GSSAPIContext();
         $gssapi->acquireCredentials(self::$ccache, $principal, \GSS_C_INITIATE);
         return new self($gssapi, $principal);
     }
@@ -73,7 +82,6 @@ class Gssapi extends Mechanism
      * get sasl authenticate mechanism name
      *
      * @access public
-     * @return string
      */
     public function getName(): string
     {

--- a/src/Sasl/Gssapi.php
+++ b/src/Sasl/Gssapi.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Sasl;
 
 use GSSAPIContext;

--- a/src/Sasl/Mechanism.php
+++ b/src/Sasl/Mechanism.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Sasl;
 
 use Kafka\CommonSocket;

--- a/src/Sasl/Mechanism.php
+++ b/src/Sasl/Mechanism.php
@@ -5,8 +5,9 @@ use Kafka\CommonSocket;
 use Kafka\Exception;
 use Kafka\Protocol;
 use Kafka\Protocol\Protocol as ProtocolTool;
+use Kafka\SaslMechanism;
 
-abstract class Mechanism implements \Kafka\SaslMechanism
+abstract class Mechanism implements SaslMechanism
 {
 
     public function authenticate(CommonSocket $socket): void

--- a/src/Sasl/Mechanism.php
+++ b/src/Sasl/Mechanism.php
@@ -22,7 +22,7 @@ abstract class Mechanism implements SaslMechanism
      * @access protected
      * @return void
      */
-    protected function handShake(CommonSocket $socket, string $mechanism) : void
+    protected function handShake(CommonSocket $socket, string $mechanism): void
     {
         $requestData = Protocol::encode(\Kafka\Protocol::SASL_HAND_SHAKE_REQUEST, [$mechanism]);
         $socket->writeBlocking($requestData);

--- a/src/Sasl/Mechanism.php
+++ b/src/Sasl/Mechanism.php
@@ -20,7 +20,6 @@ abstract class Mechanism implements SaslMechanism
      * sasl authenticate hand shake
      *
      * @access protected
-     * @return void
      */
     protected function handShake(CommonSocket $socket, string $mechanism): void
     {

--- a/src/Sasl/Mechanism.php
+++ b/src/Sasl/Mechanism.php
@@ -9,7 +9,6 @@ use Kafka\SaslMechanism;
 
 abstract class Mechanism implements SaslMechanism
 {
-
     public function authenticate(CommonSocket $socket): void
     {
         $this->handShake($socket, $this->getName());

--- a/src/Sasl/Mechanism.php
+++ b/src/Sasl/Mechanism.php
@@ -30,8 +30,8 @@ abstract class Mechanism implements SaslMechanism
         $dataLen = ProtocolTool::unpack(\Kafka\Protocol\Protocol::BIT_B32, $socket->readBlocking(4));
 
         $data          = $socket->readBlocking($dataLen);
-        $correlationId = ProtocolTool::unpack(\Kafka\Protocol\Protocol::BIT_B32, substr($data, 0, 4));
-        $result        = Protocol::decode(\Kafka\Protocol::SASL_HAND_SHAKE_REQUEST, substr($data, 4));
+        $correlationId = ProtocolTool::unpack(\Kafka\Protocol\Protocol::BIT_B32, \substr($data, 0, 4));
+        $result        = Protocol::decode(\Kafka\Protocol::SASL_HAND_SHAKE_REQUEST, \substr($data, 4));
 
         if ($result['errorCode'] !== Protocol::NO_ERROR) {
             throw new Exception(Protocol::getError($result['errorCode']));

--- a/src/Sasl/Plain.php
+++ b/src/Sasl/Plain.php
@@ -26,7 +26,7 @@ class Plain extends Mechanism
         $this->password = trim($password);
     }
 
-    protected function performAuthentication(CommonSocket $socket) : void
+    protected function performAuthentication(CommonSocket $socket): void
     {
         $split = Protocol::pack(Protocol::BIT_B8, '0');
 
@@ -39,7 +39,7 @@ class Plain extends Mechanism
         $socket->readBlocking(4);
     }
 
-    public function getName() : string
+    public function getName(): string
     {
         return self::MECHANISM_NAME;
     }

--- a/src/Sasl/Plain.php
+++ b/src/Sasl/Plain.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kafka\Sasl;
 

--- a/src/Sasl/Plain.php
+++ b/src/Sasl/Plain.php
@@ -8,7 +8,7 @@ use Kafka\Protocol\Protocol;
 
 class Plain extends Mechanism
 {
-    private const MECHANISM_NAME = "PLAIN";
+    private const MECHANISM_NAME = 'PLAIN';
 
     /**
      * @var string

--- a/src/Sasl/Plain.php
+++ b/src/Sasl/Plain.php
@@ -23,8 +23,8 @@ class Plain extends Mechanism
 
     public function __construct(string $username, string $password)
     {
-        $this->username = trim($username);
-        $this->password = trim($password);
+        $this->username = \trim($username);
+        $this->password = \trim($password);
     }
 
     protected function performAuthentication(CommonSocket $socket): void

--- a/src/Sasl/Scram.php
+++ b/src/Sasl/Scram.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka\Sasl;
 
 use Kafka\CommonSocket;

--- a/src/Sasl/Scram.php
+++ b/src/Sasl/Scram.php
@@ -12,7 +12,7 @@ class Scram extends Mechanism
     public const SCRAM_SHA_256 = 256;
     public const SCRAM_SHA_512 = 512;
 
-    private const MECHANISM_NAME = "SCRAM-SHA-";
+    private const MECHANISM_NAME = 'SCRAM-SHA-';
 
     private const ALLOW_SHA_ALGORITHM = [
         self::SCRAM_SHA_256 => 'sha256',
@@ -186,7 +186,7 @@ class Scram extends Mechanism
         }
 
         $proposedServerSignature = base64_decode($matches[1]);
-        $serverKey               = $this->hmac($this->saltedPassword, "Server Key", true);
+        $serverKey               = $this->hmac($this->saltedPassword, 'Server Key', true);
         $serverSignature         = $this->hmac($serverKey, $this->authMessage, true);
         return hash_equals($proposedServerSignature, $serverSignature);
     }

--- a/src/Sasl/Scram.php
+++ b/src/Sasl/Scram.php
@@ -70,7 +70,7 @@ class Scram extends Mechanism
      * @throws \Kafka\Exception
      * @throws \Exception
      */
-    protected function performAuthentication(CommonSocket $socket) : void
+    protected function performAuthentication(CommonSocket $socket): void
     {
         $firstMessage = $this->firstMessage();
         $data         = ProtocolTool::encodeString($firstMessage, ProtocolTool::PACK_INT32);
@@ -90,7 +90,7 @@ class Scram extends Mechanism
     }
 
 
-    public function getName() : string
+    public function getName(): string
     {
         return self::MECHANISM_NAME . $this->hashAlgorithm;
     }
@@ -98,7 +98,7 @@ class Scram extends Mechanism
     /**
      * @throws \Exception
      */
-    protected function firstMessage() : string
+    protected function firstMessage(): string
     {
         $this->cnonce = $this->generateNonce();
         $message      = sprintf('n,,n=%s,r=%s', $this->username, $this->cnonce);
@@ -111,7 +111,7 @@ class Scram extends Mechanism
     /**
      * @throws \Kafka\Exception
      */
-    protected function finalMessage(string $challenge) : string
+    protected function finalMessage(string $challenge): string
     {
         $challengeArray = explode(',', $challenge);
 
@@ -171,7 +171,7 @@ class Scram extends Mechanism
      *
       * @return bool Whether the server has been authenticated.
       */
-    protected function verifyMessage(string $data) : bool
+    protected function verifyMessage(string $data): bool
     {
         $verifierRegexp = '#^v=((?:[A-Za-z0-9/+]{4})*(?:[A-Za-z0-9]{3}=|[A-Xa-z0-9]{2}==)?)$#';
 
@@ -192,7 +192,7 @@ class Scram extends Mechanism
     /**
      * @throws \Exception
      */
-    protected function generateNonce() : string
+    protected function generateNonce(): string
     {
         $str = '';
 
@@ -203,12 +203,12 @@ class Scram extends Mechanism
         return base64_encode($str);
     }
 
-    private function hash(string $data) : string
+    private function hash(string $data): string
     {
         return \hash(self::ALLOW_SHA_ALGORITHM[$this->hashAlgorithm], $data, true);
     }
 
-    private function hmac(string $key, string $data, bool $raw) : string
+    private function hmac(string $key, string $data, bool $raw): string
     {
         return \hash_hmac(self::ALLOW_SHA_ALGORITHM[$this->hashAlgorithm], $data, $key, $raw);
     }
@@ -220,7 +220,7 @@ class Scram extends Mechanism
     * @param string $user a name to be prepared.
     * @return string the reformatted name.
     */
-    private function formatName(string $user) : string
+    private function formatName(string $user): string
     {
         return str_replace(['=', ','], ['=3D', '=2C'], $user);
     }
@@ -228,7 +228,7 @@ class Scram extends Mechanism
   /**
     * Hi() call, which is essentially PBKDF2 (RFC-2898) with HMAC-H() as the pseudorandom function.
     */
-    private function hi(string $str, string $salt, int $icnt) : string
+    private function hi(string $str, string $salt, int $icnt): string
     {
         $int1   = "\0\0\0\1";
         $ui     = $this->hmac($str, $salt . $int1, true);

--- a/src/Sasl/Scram.php
+++ b/src/Sasl/Scram.php
@@ -64,8 +64,8 @@ class Scram extends Mechanism
         }
 
         $this->hashAlgorithm = $algorithm;
-        $this->username      = $this->formatName(trim($username));
-        $this->password      = trim($password);
+        $this->username      = $this->formatName(\trim($username));
+        $this->password      = \trim($password);
     }
 
     /**
@@ -103,9 +103,9 @@ class Scram extends Mechanism
     protected function firstMessage(): string
     {
         $this->cnonce = $this->generateNonce();
-        $message      = sprintf('n,,n=%s,r=%s', $this->username, $this->cnonce);
+        $message      = \sprintf('n,,n=%s,r=%s', $this->username, $this->cnonce);
 
-        $this->firstMessageBare = substr($message, 3);
+        $this->firstMessageBare = \substr($message, 3);
 
         return $message;
     }
@@ -115,21 +115,21 @@ class Scram extends Mechanism
      */
     protected function finalMessage(string $challenge): string
     {
-        $challengeArray = explode(',', $challenge);
+        $challengeArray = \explode(',', $challenge);
 
-        if (count($challengeArray) < 3) {
+        if (\count($challengeArray) < 3) {
             throw new Exception('Server response challenge is invalid.');
         }
 
-        $nonce = substr($challengeArray[0], 2);
-        $salt  = base64_decode(substr($challengeArray[1], 2));
+        $nonce = \substr($challengeArray[0], 2);
+        $salt  = \base64_decode(\substr($challengeArray[1], 2));
 
         if (! $salt) {
             throw new Exception('Server response challenge is invalid, paser salt is failure.');
         }
 
-        $i      = (int) substr($challengeArray[2], 2);
-        $cnonce = substr($nonce, 0, strlen($this->cnonce));
+        $i      = (int) \substr($challengeArray[2], 2);
+        $cnonce = \substr($nonce, 0, \strlen($this->cnonce));
 
         if ($cnonce !== $this->cnonce) {
             throw new Exception('Server response challenge is invalid, cnonce is invalid.');
@@ -161,7 +161,7 @@ class Scram extends Mechanism
 
         $clientSignature = $this->hmac($storedKey, $authMessage, true);
         $clientProof     = $clientKey ^ $clientSignature;
-        $proof           = ',p=' . base64_encode($clientProof);
+        $proof           = ',p=' . \base64_encode($clientProof);
 
         return $finalMessage . $proof;
     }
@@ -181,14 +181,14 @@ class Scram extends Mechanism
             return false;
         }
 
-        if (! preg_match($verifierRegexp, $data, $matches)) {
+        if (! \preg_match($verifierRegexp, $data, $matches)) {
             return false;
         }
 
-        $proposedServerSignature = base64_decode($matches[1]);
+        $proposedServerSignature = \base64_decode($matches[1]);
         $serverKey               = $this->hmac($this->saltedPassword, 'Server Key', true);
         $serverSignature         = $this->hmac($serverKey, $this->authMessage, true);
-        return hash_equals($proposedServerSignature, $serverSignature);
+        return \hash_equals($proposedServerSignature, $serverSignature);
     }
 
     /**
@@ -202,7 +202,7 @@ class Scram extends Mechanism
             $str .= \chr(\random_int(0, 255));
         }
 
-        return base64_encode($str);
+        return \base64_encode($str);
     }
 
     private function hash(string $data): string
@@ -224,7 +224,7 @@ class Scram extends Mechanism
     */
     private function formatName(string $user): string
     {
-        return str_replace(['=', ','], ['=3D', '=2C'], $user);
+        return \str_replace(['=', ','], ['=3D', '=2C'], $user);
     }
 
   /**

--- a/src/SaslMechanism.php
+++ b/src/SaslMechanism.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 interface SaslMechanism

--- a/src/SaslMechanism.php
+++ b/src/SaslMechanism.php
@@ -8,7 +8,6 @@ interface SaslMechanism
      * sasl authenticate
      *
      * @access public
-     * @return void
      */
     public function authenticate(CommonSocket $socket): void;
 }

--- a/src/SaslMechanism.php
+++ b/src/SaslMechanism.php
@@ -10,5 +10,5 @@ interface SaslMechanism
      * @access public
      * @return void
      */
-    public function authenticate(CommonSocket $socket) : void;
+    public function authenticate(CommonSocket $socket): void;
 }

--- a/src/SingletonTrait.php
+++ b/src/SingletonTrait.php
@@ -1,10 +1,12 @@
 <?php
 namespace Kafka;
 
+use Psr\Log\LoggerAwareTrait;
+
 trait SingletonTrait
 {
-    use \Psr\Log\LoggerAwareTrait;
-    use \Kafka\LoggerTrait;
+    use LoggerAwareTrait;
+    use LoggerTrait;
 
     protected static $instance;
 

--- a/src/SingletonTrait.php
+++ b/src/SingletonTrait.php
@@ -8,8 +8,14 @@ trait SingletonTrait
     use LoggerAwareTrait;
     use LoggerTrait;
 
+    /**
+     * @var object
+     */
     protected static $instance;
 
+    /**
+     * @return object
+     */
     public static function getInstance()
     {
         if (self::$instance === null) {

--- a/src/SingletonTrait.php
+++ b/src/SingletonTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Psr\Log\LoggerAwareTrait;

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 use Amp\Loop;
@@ -44,7 +46,7 @@ class Socket extends CommonSocket
 
         $this->createStream();
 
-        stream_set_blocking($this->stream, 0);
+        stream_set_blocking($this->stream, false);
         stream_set_read_buffer($this->stream, 0);
 
         $this->readWatcherId = Loop::onReadable(

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -46,8 +46,8 @@ class Socket extends CommonSocket
 
         $this->createStream();
 
-        stream_set_blocking($this->stream, false);
-        stream_set_read_buffer($this->stream, 0);
+        \stream_set_blocking($this->stream, false);
+        \stream_set_read_buffer($this->stream, 0);
 
         $this->readWatcherId = Loop::onReadable(
             $this->stream,
@@ -58,7 +58,7 @@ class Socket extends CommonSocket
                         return;
                     }
 
-                    $newData = @fread($this->stream, self::READ_MAX_LENGTH);
+                    $newData = @\fread($this->stream, self::READ_MAX_LENGTH);
 
                     if ($newData) {
                         $this->read($newData);
@@ -92,8 +92,8 @@ class Socket extends CommonSocket
         Loop::cancel($this->readWatcherId);
         Loop::cancel($this->writeWatcherId);
 
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
+        if (\is_resource($this->stream)) {
+            \fclose($this->stream);
         }
 
         $this->readBuffer     = '';
@@ -103,7 +103,7 @@ class Socket extends CommonSocket
 
     public function isResource(): bool
     {
-        return is_resource($this->stream);
+        return \is_resource($this->stream);
     }
 
     /**
@@ -120,26 +120,26 @@ class Socket extends CommonSocket
 
         do {
             if ($this->readNeedLength === 0) { // response start
-                if (strlen($this->readBuffer) < 4) {
+                if (\strlen($this->readBuffer) < 4) {
                     return;
                 }
 
-                $dataLen              = Protocol::unpack(Protocol::BIT_B32, substr($this->readBuffer, 0, 4));
+                $dataLen              = Protocol::unpack(Protocol::BIT_B32, \substr($this->readBuffer, 0, 4));
                 $this->readNeedLength = $dataLen;
-                $this->readBuffer     = substr($this->readBuffer, 4);
+                $this->readBuffer     = \substr($this->readBuffer, 4);
             }
 
-            if (strlen($this->readBuffer) < $this->readNeedLength) {
+            if (\strlen($this->readBuffer) < $this->readNeedLength) {
                 return;
             }
 
-            $data = (string) substr($this->readBuffer, 0, $this->readNeedLength);
+            $data = (string) \substr($this->readBuffer, 0, $this->readNeedLength);
 
-            $this->readBuffer     = substr($this->readBuffer, $this->readNeedLength);
+            $this->readBuffer     = \substr($this->readBuffer, $this->readNeedLength);
             $this->readNeedLength = 0;
 
             ($this->onReadable)($data, (int) $this->stream);
-        } while (strlen($this->readBuffer));
+        } while (\strlen($this->readBuffer));
     }
 
     /**
@@ -153,8 +153,8 @@ class Socket extends CommonSocket
             $this->writeBuffer .= $data;
         }
 
-        $bytesToWrite = strlen($this->writeBuffer);
-        $bytesWritten = @fwrite($this->stream, $this->writeBuffer);
+        $bytesToWrite = \strlen($this->writeBuffer);
+        $bytesWritten = @\fwrite($this->stream, $this->writeBuffer);
 
         if ($bytesToWrite === $bytesWritten) {
             Loop::disable($this->writeWatcherId);
@@ -164,7 +164,7 @@ class Socket extends CommonSocket
             $this->reconnect();
         }
 
-        $this->writeBuffer = substr($this->writeBuffer, $bytesWritten);
+        $this->writeBuffer = \substr($this->writeBuffer, $bytesWritten);
     }
 
     /**
@@ -172,6 +172,6 @@ class Socket extends CommonSocket
      */
     protected function isSocketDead(): bool
     {
-        return ! is_resource($this->stream) || @feof($this->stream);
+        return ! \is_resource($this->stream) || @\feof($this->stream);
     }
 }

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -84,7 +84,7 @@ class Socket extends CommonSocket
         $this->onReadable = $read;
     }
 
-    public function close() : void
+    public function close(): void
     {
         Loop::cancel($this->readWatcherId);
         Loop::cancel($this->writeWatcherId);

--- a/src/SocketSync.php
+++ b/src/SocketSync.php
@@ -14,12 +14,6 @@ class SocketSync extends CommonSocket
         stream_set_blocking($this->stream, 0);
     }
 
-    /**
-     * close the socket
-     *
-     * @access public
-     * @return void
-     */
     public function close() : void
     {
         if (is_resource($this->stream)) {
@@ -27,12 +21,6 @@ class SocketSync extends CommonSocket
         }
     }
 
-    /**
-     * checks if the socket is a valid resource
-     *
-     * @access public
-     * @return boolean
-     */
     public function isResource()
     {
         return is_resource($this->stream);
@@ -44,34 +32,21 @@ class SocketSync extends CommonSocket
      * This method will not wait for all the requested data, it will return as
      * soon as any data is received.
      *
-     * @param integer $len               Maximum number of bytes to read.
-     *
-     * @return string Binary data
      * @throws \Kafka\Exception
      */
-    public function read(int $len) : string
+    public function read(int $length) : string
     {
-        return $this->readBlocking($len);
+        return $this->readBlocking($length);
     }
 
     /**
-     * Write to the socket.
-     *
-     * @param string $buf The data to write
-     *
-     * @return integer
      * @throws \Kafka\Exception
      */
-    public function write(string $buf) : int
+    public function write(string $buffer) : int
     {
-        return $this->writeBlocking($buf);
+        return $this->writeBlocking($buffer);
     }
 
-    /**
-     * Rewind the stream
-     *
-     * @return void
-     */
     public function rewind()
     {
         if (is_resource($this->stream)) {

--- a/src/SocketSync.php
+++ b/src/SocketSync.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Kafka;
 
 class SocketSync extends CommonSocket
@@ -11,7 +13,7 @@ class SocketSync extends CommonSocket
 
         $this->createStream();
 
-        stream_set_blocking($this->stream, 0);
+        stream_set_blocking($this->stream, false);
     }
 
     public function close(): void

--- a/src/SocketSync.php
+++ b/src/SocketSync.php
@@ -7,25 +7,25 @@ class SocketSync extends CommonSocket
 {
     public function connect(): void
     {
-        if (is_resource($this->stream)) {
+        if (\is_resource($this->stream)) {
             return;
         }
 
         $this->createStream();
 
-        stream_set_blocking($this->stream, false);
+        \stream_set_blocking($this->stream, false);
     }
 
     public function close(): void
     {
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
+        if (\is_resource($this->stream)) {
+            \fclose($this->stream);
         }
     }
 
     public function isResource(): bool
     {
-        return is_resource($this->stream);
+        return \is_resource($this->stream);
     }
 
     /**
@@ -52,8 +52,8 @@ class SocketSync extends CommonSocket
 
     public function rewind(): void
     {
-        if (is_resource($this->stream)) {
-            rewind($this->stream);
+        if (\is_resource($this->stream)) {
+            \rewind($this->stream);
         }
     }
 }

--- a/src/SocketSync.php
+++ b/src/SocketSync.php
@@ -21,33 +21,34 @@ class SocketSync extends CommonSocket
         }
     }
 
-    public function isResource()
+    public function isResource(): bool
     {
         return is_resource($this->stream);
     }
 
     /**
-     * Read from the socket at most $len bytes.
-     *
-     * This method will not wait for all the requested data, it will return as
-     * soon as any data is received.
+     * @param string|int $data
      *
      * @throws \Kafka\Exception
      */
-    public function read(int $length): string
+    public function read($data): string
     {
-        return $this->readBlocking($length);
+        return $this->readBlocking((int) $data);
     }
 
     /**
      * @throws \Kafka\Exception
      */
-    public function write(string $buffer): int
+    public function write(?string $buffer = null): int
     {
+        if ($buffer === null) {
+            throw new Exception('You must inform some data to be written');
+        }
+
         return $this->writeBlocking($buffer);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         if (is_resource($this->stream)) {
             rewind($this->stream);

--- a/src/SocketSync.php
+++ b/src/SocketSync.php
@@ -14,7 +14,7 @@ class SocketSync extends CommonSocket
         stream_set_blocking($this->stream, 0);
     }
 
-    public function close() : void
+    public function close(): void
     {
         if (is_resource($this->stream)) {
             fclose($this->stream);
@@ -34,7 +34,7 @@ class SocketSync extends CommonSocket
      *
      * @throws \Kafka\Exception
      */
-    public function read(int $length) : string
+    public function read(int $length): string
     {
         return $this->readBlocking($length);
     }
@@ -42,7 +42,7 @@ class SocketSync extends CommonSocket
     /**
      * @throws \Kafka\Exception
      */
-    public function write(string $buffer) : int
+    public function write(string $buffer): int
     {
         return $this->writeBlocking($buffer);
     }

--- a/tests/Base/BrokerTest.php
+++ b/tests/Base/BrokerTest.php
@@ -1,46 +1,28 @@
 <?php
 namespace KafkaTest\Base;
 
-use PHPUnit\Framework\TestCase;
 use Kafka\Broker;
 use Kafka\Socket;
 use Kafka\SocketSync;
+use PHPUnit\Framework\TestCase;
 
 class BrokerTest extends TestCase
 {
-    /**
-     * setDown
-     *
-     * @access public
-     * @return void
-     */
-    public function tearDown()
+    public function tearDown(): void
     {
         Broker::getInstance()->clear();
     }
 
-    /**
-     * testGroupBrokerId
-     *
-     * @access public
-     * @return void
-     */
-    public function testGroupBrokerId()
+    public function testGroupBrokerId(): void
     {
-        $broker = \Kafka\Broker::getInstance();
+        $broker = Broker::getInstance();
         $broker->setGroupBrokerId(1);
         $this->assertEquals($broker->getGroupBrokerId(), 1);
     }
 
-    /**
-     * testData
-     *
-     * @access public
-     * @return void
-     */
-    public function testData()
+    public function testData(): void
     {
-        $broker = \Kafka\Broker::getInstance();
+        $broker = Broker::getInstance();
         $data   = [
             'brokers' => [
                 [
@@ -110,15 +92,9 @@ class BrokerTest extends TestCase
         $this->assertEquals($topics, $broker->getTopics());
     }
 
-    /**
-     * testGetConnect
-     *
-     * @access public
-     * @return void
-     */
-    public function getConnect()
+    public function getConnect(): void
     {
-        $broker = \Kafka\Broker::getInstance();
+        $broker = Broker::getInstance();
         $data   = [
             [
                 'host' => '127.0.0.1',
@@ -149,29 +125,17 @@ class BrokerTest extends TestCase
         $this->assertFalse($result);
     }
 
-    /**
-     * testGetConnect
-     *
-     * @access public
-     * @return void
-     */
-    public function testConnectRandFalse()
+    public function testConnectRandFalse(): void
     {
-        $broker = \Kafka\Broker::getInstance();
+        $broker = Broker::getInstance();
 
         $result = $broker->getRandConnect();
-        $this->assertFalse($result);
+        $this->assertNull($result);
     }
 
-    /**
-     * testGetSocket
-     *
-     * @access public
-     * @return void
-     */
-    public function testGetSocketNotSetConfig()
+    public function testGetSocketNotSetConfig(): void
     {
-        $broker   = \Kafka\Broker::getInstance();
+        $broker   = Broker::getInstance();
         $hostname = '127.0.0.1';
         $port     = '9092';
         $socket   = $broker->getSocket($hostname, $port, true);

--- a/tests/Base/BrokerTest.php
+++ b/tests/Base/BrokerTest.php
@@ -94,13 +94,13 @@ class BrokerTest extends \PHPUnit\Framework\TestCase
         $brokers = [
             0 => '127.0.0.1:9092',
             1 => '127.0.0.1:9192',
-            2 => '127.0.0.1:9292'
+            2 => '127.0.0.1:9292',
         ];
         $topics  = [
             'test' => [
                 0 => 0,
                 1 => 2,
-            ]
+            ],
         ];
         $this->assertEquals($brokers, $broker->getBrokers());
         $this->assertEquals($topics, $broker->getTopics());

--- a/tests/Base/BrokerTest.php
+++ b/tests/Base/BrokerTest.php
@@ -8,7 +8,6 @@ use Kafka\SocketSync;
 
 class BrokerTest extends TestCase
 {
-
     /**
      * setDown
      *

--- a/tests/Base/BrokerTest.php
+++ b/tests/Base/BrokerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Base;
 
 use Kafka\Broker;
@@ -17,12 +19,13 @@ class BrokerTest extends TestCase
     {
         $broker = Broker::getInstance();
         $broker->setGroupBrokerId(1);
-        $this->assertEquals($broker->getGroupBrokerId(), 1);
+
+        $this->assertSame($broker->getGroupBrokerId(), 1);
     }
 
     public function testData(): void
     {
-        $broker = Broker::getInstance();
+        $broker = $this->getBroker();
         $data   = [
             'brokers' => [
                 [
@@ -94,7 +97,7 @@ class BrokerTest extends TestCase
 
     public function getConnect(): void
     {
-        $broker = Broker::getInstance();
+        $broker = $this->getBroker();
         $data   = [
             [
                 'host' => '127.0.0.1',
@@ -122,12 +125,12 @@ class BrokerTest extends TestCase
             ->getMock();
 
         $result = $broker->getMetaConnect('1');
-        $this->assertFalse($result);
+        $this->assertNull($result);
     }
 
     public function testConnectRandFalse(): void
     {
-        $broker = Broker::getInstance();
+        $broker = $this->getBroker();
 
         $result = $broker->getRandConnect();
         $this->assertNull($result);
@@ -135,11 +138,16 @@ class BrokerTest extends TestCase
 
     public function testGetSocketNotSetConfig(): void
     {
-        $broker   = Broker::getInstance();
+        $broker   = $this->getBroker();
         $hostname = '127.0.0.1';
-        $port     = '9092';
+        $port     = 9092;
         $socket   = $broker->getSocket($hostname, $port, true);
 
         $this->assertInstanceOf(SocketSync::class, $socket);
+    }
+
+    private function getBroker(): Broker
+    {
+        return Broker::getInstance();
     }
 }

--- a/tests/Base/BrokerTest.php
+++ b/tests/Base/BrokerTest.php
@@ -1,7 +1,12 @@
 <?php
 namespace KafkaTest\Base;
 
-class BrokerTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use Kafka\Broker;
+use Kafka\Socket;
+use Kafka\SocketSync;
+
+class BrokerTest extends TestCase
 {
 
     /**
@@ -12,7 +17,7 @@ class BrokerTest extends \PHPUnit\Framework\TestCase
      */
     public function tearDown()
     {
-        \Kafka\Broker::getInstance()->clear();
+        Broker::getInstance()->clear();
     }
 
     /**
@@ -134,7 +139,7 @@ class BrokerTest extends \PHPUnit\Framework\TestCase
         ];
         $broker->setData([], $data);
 
-        $socket = $this->getMockBuilder(\Kafka\Socket::class)
+        $socket = $this->getMockBuilder(Socket::class)
             ->setConstructorArgs(['127.0.0.1', '9192'])
             ->disableOriginalClone()
             ->disableArgumentCloning()
@@ -172,6 +177,6 @@ class BrokerTest extends \PHPUnit\Framework\TestCase
         $port     = '9092';
         $socket   = $broker->getSocket($hostname, $port, true);
 
-        $this->assertInstanceOf(\Kafka\SocketSync::class, $socket);
+        $this->assertInstanceOf(SocketSync::class, $socket);
     }
 }

--- a/tests/Base/ConfigTest.php
+++ b/tests/Base/ConfigTest.php
@@ -1,0 +1,452 @@
+<?php
+declare(strict_types=1);
+
+namespace KafkaTest\Base;
+
+use Kafka\Config;
+use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class ConfigTest extends TestCase
+{
+    /**
+     * @var Config|MockObject
+     */
+    private $config;
+
+    /**
+     * @before
+     */
+    public function createConfig(): void
+    {
+        $this->config = $this->getMockForAbstractClass(Config::class);
+    }
+
+    /**
+     * @after
+     */
+    public function cleanUpInstance(): void
+    {
+        $this->config->clear();
+    }
+
+    /**
+     * @test
+     */
+    public function defaultValuesShouldBeRetrievedWhenNothingWasConfigured(): void
+    {
+        self::assertSame('kafka-php', $this->config->getClientId());
+        self::assertSame('0.10.1.0', $this->config->getBrokerVersion());
+        self::assertSame('', $this->config->getMetadataBrokerList());
+        self::assertSame(1000000, $this->config->getMessageMaxBytes());
+        self::assertSame(60000, $this->config->getMetadataRequestTimeoutMs());
+        self::assertSame(300000, $this->config->getMetadataRefreshIntervalMs());
+        self::assertSame(-1, $this->config->getMetadataMaxAgeMs());
+    }
+
+    public function clearShouldResetConfigurationToItsDefaults(): void
+    {
+        $this->config->setClientId('my-client');
+        $this->config->clear();
+
+        self::assertSame('kafka-php', $this->config->getClientId());
+    }
+
+    /**
+     * @test
+     *
+     * TODO: kill this with fire
+     */
+    public function randomDataCanBeConfiguredUsingMagicMethods(): void
+    {
+        self::assertFalse($this->config->setValidKey('xxx', '222'));
+        self::assertFalse($this->config->getValidKey());
+
+        $this->config->setValidKey('222');
+        self::assertSame($this->config->getValidKey(), '222');
+    }
+
+    /**
+     * @test
+     *
+     * TODO: kill this with fire
+     */
+    public function magicMethodShouldReturnFalseWhenCallingAMethodThatIsNeitherGetterOrSetter(): void
+    {
+        self::assertFalse($this->config->pureMagic());
+    }
+
+    /**
+     * @test
+     */
+    public function setClientIdShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setClientId('kafka-php1');
+
+        self::assertSame('kafka-php1', $this->config->getClientId());
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set clientId value is invalid, must is not empty string.
+     */
+    public function setClientIdShouldRaiseAnExceptionWhenIdIsEmpty(): void
+    {
+        $this->config->setClientId('');
+    }
+
+    /**
+     * @test
+     */
+    public function setBrokerVersionShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setBrokerVersion('0.9.0.1');
+
+        self::assertSame('0.9.0.1', $this->config->getBrokerVersion());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidBrokerVersion
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set broker version value is invalid, must is not empty string and gt 0.8.0.
+     */
+    public function setBrokerVersionShouldRaiseExceptionWhenInvalidDataIsGiven(string $brokerVersion): void
+    {
+        $this->config->setBrokerVersion($brokerVersion);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function invalidBrokerVersion(): array
+    {
+        return [
+            [''],
+            ['0.1'],
+            ['0.2'],
+            ['0.3'],
+            ['0.4'],
+            ['0.5'],
+            ['0.6'],
+            ['0.7'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function setMetadataBrokerListShouldTrimSpacesFromGivenData(): void
+    {
+        $this->config->setMetadataBrokerList(' 127.0.0.1:9192,127.0.0.1:9292 '); // with whitespace to ensure that the list is trimmed
+
+        self::assertSame('127.0.0.1:9192,127.0.0.1:9292', $this->config->getMetadataBrokerList());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidBrokerList
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Broker list must be a comma-separated list of brokers (format: "host:port"), with at least one broker
+     */
+    public function setMetadataBrokerListShouldRaiseAnExceptionWhenInvalidDataIsGiven(string $brokerList): void
+    {
+        $this->config->setMetadataBrokerList($brokerList);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function invalidBrokerList(): array
+    {
+        return [
+            [''],
+            [','],
+            ['127.0.0.1: , : '],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function setMessageMaxBytesShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setMessageMaxBytes(1011);
+
+        self::assertSame(1011, $this->config->getMessageMaxBytes());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidMessageMaxBytes
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set message max bytes value is invalid, must set it 1000 .. 1000000000
+     */
+    public function setMessageMaxBytesShouldRaiseExceptionWhenInvalidDataIsGiven(int $messageMaxBytes): void
+    {
+        $this->config->setMessageMaxBytes($messageMaxBytes);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function invalidMessageMaxBytes(): array
+    {
+        return [
+            [999],
+            [1000000001],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function setMetadataRequestTimeoutMsShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setMetadataRequestTimeoutMs(1011);
+
+        self::assertSame(1011, $this->config->getMetadataRequestTimeoutMs());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidMetadataRequestTimeoutMs
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set metadata request timeout value is invalid, must set it 10 .. 900000
+     */
+    public function testSetMetadataRequestTimeoutMsShouldRaiseExceptionWhenInvalidDataIsGiven(int $metadataRequestTimeoutMs): void
+    {
+        $this->config->setMetadataRequestTimeoutMs($metadataRequestTimeoutMs);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function invalidMetadataRequestTimeoutMs(): array
+    {
+        return [
+            [9],
+            [900001],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function setMetadataRefreshIntervalMsShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setMetadataRefreshIntervalMs(1011);
+
+        self::assertSame(1011, $this->config->getMetadataRefreshIntervalMs());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidMetadataRefreshIntervalMs
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set metadata refresh interval value is invalid, must set it 10 .. 3600000
+     */
+    public function setMetadataRefreshIntervalMsShouldRaiseExceptionWhenInvalidDataIsGiven(int $metadataRefreshIntervalMs): void
+    {
+        $this->config->setMetadataRefreshIntervalMs($metadataRefreshIntervalMs);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function invalidMetadataRefreshIntervalMs(): array
+    {
+        return [
+            [9],
+            [3600001],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function setMetadataMaxAgeMsShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setMetadataMaxAgeMs(1011);
+
+        self::assertSame(1011, $this->config->getMetadataMaxAgeMs());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidMetadataMaxAgeMs
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set metadata max age value is invalid, must set it 1 .. 86400000
+     */
+    public function setMetadataMaxAgeMsShouldRaiseExceptionWhenInvalidDataIsGiven(int $metadataMaxAgeMs): void
+    {
+        $this->config->setMetadataMaxAgeMs($metadataMaxAgeMs);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function invalidMetadataMaxAgeMs(): array
+    {
+        return [
+            [0],
+            [86400001],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function setSslLocalCertShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setSslLocalCert('/etc/passwd');
+
+        self::assertSame('/etc/passwd', $this->config->getSslLocalCert());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidFiles
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set ssl local cert file is invalid
+     */
+    public function setSslLocalCertShouldRaiseExceptionWhenInvalidDataIsGiven(string $file): void
+    {
+        $this->config->setSslLocalCert($file);
+    }
+
+    /**
+     * @test
+     */
+    public function setSslLocalPkShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setSslLocalPk('/etc/passwd');
+
+        self::assertSame('/etc/passwd', $this->config->getSslLocalPk());
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set ssl local private key file is invalid
+     */
+    public function setSslLocalPkShouldRaiseExceptionWhenInvalidDataIsGiven(): void
+    {
+        $this->config->setSslLocalPk('invalid_path');
+    }
+
+    /**
+     * @test
+     */
+    public function setSslCafileShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setSslCafile('/etc/passwd');
+
+        self::assertSame('/etc/passwd', $this->config->getSslCafile());
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set ssl ca file is invalid
+     */
+    public function setSslCafileShouldRaiseExceptionWhenInvalidDataIsGiven(): void
+    {
+        $this->config->setSslCafile('invalid_path');
+    }
+
+    /**
+     * @test
+     */
+    public function setSaslKeytabShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setSaslKeytab('/etc/passwd');
+
+        self::assertSame('/etc/passwd', $this->config->getSaslKeytab());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidFiles
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Set sasl gssapi keytab file is invalid
+     */
+    public function setSaslKeytabShouldRaiseExceptionWhenInvalidDataIsGiven(string $file): void
+    {
+        $this->config->setSaslKeytab($file);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function invalidFiles(): array
+    {
+        return [
+            ['invalid_path'],
+            ['/tmp'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function setSecurityProtocolShouldConfigureTheAttributeProperly(): void
+    {
+        $this->config->setSecurityProtocol(Config::SECURITY_PROTOCOL_PLAINTEXT);
+
+        self::assertSame(Config::SECURITY_PROTOCOL_PLAINTEXT, $this->config->getSecurityProtocol());
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Invalid security protocol given.
+     */
+    public function setSecurityProtocolShouldRaiseExceptionWhenInvalidDataIsGiven(): void
+    {
+        $this->config->setSecurityProtocol('xxxx');
+    }
+
+    /**
+     * @test
+     */
+    public function setSaslMechanismShouldConfigureTheAttributeProperly(): void
+    {
+        $mechanism = Config::SASL_MECHANISMS_GSSAPI;
+        $this->config->setSaslMechanism($mechanism);
+
+        self::assertSame($mechanism, $this->config->getSaslMechanism());
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Kafka\Exception\Config
+     * @expectedExceptionMessage Invalid security sasl mechanism given.
+     */
+    public function setSaslMechanismShouldRaiseExceptionWhenInvalidDataIsGiven(): void
+    {
+        $this->config->setSaslMechanism('xxxx');
+    }
+}

--- a/tests/Base/Consumer/StopStrategy/CallbackTest.php
+++ b/tests/Base/Consumer/StopStrategy/CallbackTest.php
@@ -7,8 +7,9 @@ use Amp\Loop;
 use Kafka\Consumer;
 use Kafka\Consumer\StopStrategy\Callback;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-final class CallbackTest extends \PHPUnit\Framework\TestCase
+final class CallbackTest extends TestCase
 {
     /**
      * @var Consumer|MockObject

--- a/tests/Base/Consumer/StopStrategy/DelayTest.php
+++ b/tests/Base/Consumer/StopStrategy/DelayTest.php
@@ -7,8 +7,9 @@ use Amp\Loop;
 use Kafka\Consumer;
 use Kafka\Consumer\StopStrategy\Delay;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-final class DelayTest extends \PHPUnit\Framework\TestCase
+final class DelayTest extends TestCase
 {
     /**
      * @var Consumer|MockObject

--- a/tests/Base/ConsumerConfigTest.php
+++ b/tests/Base/ConsumerConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace KafkaTest\Base;
 
 use Kafka\ConsumerConfig;
+use Kafka\Exception\Config;
 use PHPUnit\Framework\TestCase;
 
 final class ConsumerConfigTest extends TestCase
@@ -27,93 +28,6 @@ final class ConsumerConfigTest extends TestCase
     public function cleanUpInstance(): void
     {
         ConsumerConfig::getInstance()->clear();
-    }
-
-    public function testDefaultConfig(): void
-    {
-        self::assertSame($this->config->getClientId(), 'kafka-php');
-        self::assertSame($this->config->getSessionTimeout(), 30000);
-
-        self::assertFalse($this->config->setValidKey('xxx', '222'));
-        self::assertFalse($this->config->getValidKey());
-
-        $this->config->setValidKey('222');
-        self::assertSame($this->config->getValidKey(), '222');
-    }
-
-    public function testSetClientId(): void
-    {
-        $this->config->setClientId('kafka-php1');
-
-        self::assertSame($this->config->getClientId(), 'kafka-php1');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set clientId value is invalid, must is not empty string.
-     */
-    public function testSetClientIdEmpty(): void
-    {
-        $this->config->setClientId('');
-    }
-
-    public function testSetBrokerVersion(): void
-    {
-        $this->config->setBrokerVersion('0.9.0.1');
-
-        self::assertSame($this->config->getBrokerVersion(), '0.9.0.1');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set broker version value is invalid, must is not empty string and gt 0.8.0.
-     */
-    public function testSetBrokerVersionEmpty(): void
-    {
-        $this->config->setBrokerVersion('');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set broker version value is invalid, must is not empty string and gt 0.8.0.
-     */
-    public function testSetBrokerVersionInvalid(): void
-    {
-        $this->config->setBrokerVersion('0.1');
-    }
-
-    public function testSetMetadataBrokerList(): void
-    {
-        $this->config->setMetadataBrokerList(' 127.0.0.1:9192,127.0.0.1:9292'); // with whitespace to ensure that the list is trimmed
-
-        self::assertSame($this->config->getMetadataBrokerList(), '127.0.0.1:9192,127.0.0.1:9292');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Broker list must be a comma-separated list of brokers (format: "host:port"), with at least one broker
-     */
-    public function testSetMetadataBrokerListEmpty(): void
-    {
-        $this->config->setMetadataBrokerList('');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Broker list must be a comma-separated list of brokers (format: "host:port"), with at least one broker
-     */
-    public function testSetMetadataBrokerListEmpty1(): void
-    {
-        $this->config->setMetadataBrokerList(',');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Broker list must be a comma-separated list of brokers (format: "host:port"), with at least one broker
-     */
-    public function testSetMetadataBrokerListEmpty2(): void
-    {
-        $this->config->setMetadataBrokerList('127.0.0.1: , : ');
     }
 
     public function testSetGroupId(): void
@@ -214,67 +128,25 @@ final class ConsumerConfigTest extends TestCase
         $this->config->getTopics();
     }
 
-    public function testSetMessageMaxBytes(): void
+    /**
+     * @test
+     */
+    public function setConsumeModeShouldConfigureTheAttributeProperly(): void
     {
-        $this->config->setMessageMaxBytes(1011);
+        self::assertSame(ConsumerConfig::CONSUME_AFTER_COMMIT_OFFSET, $this->config->getConsumeMode());
 
-        self::assertSame($this->config->getMessageMaxBytes(), 1011);
+        $this->config->setConsumeMode(ConsumerConfig::CONSUME_BEFORE_COMMIT_OFFSET);
+
+        self::assertSame(ConsumerConfig::CONSUME_BEFORE_COMMIT_OFFSET, $this->config->getConsumeMode());
     }
 
     /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set message max bytes value is invalid, must set it 1000 .. 1000000000
+     * @test
      */
-    public function testSetMessageMaxBytesInvalid(): void
+    public function setShouldThrowExceptionWhenInvalidDataIsGiven(): void
     {
-        $this->config->setMessageMaxBytes('999');
-    }
+        $this->expectException(Config::class);
 
-    public function testSetMetadataRequestTimeoutMs(): void
-    {
-        $this->config->setMetadataRequestTimeoutMs(1011);
-
-        self::assertSame($this->config->getMetadataRequestTimeoutMs(), 1011);
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set metadata request timeout value is invalid, must set it 10 .. 900000
-     */
-    public function testSetMetadataRequestTimeoutMsInvalid(): void
-    {
-        $this->config->setMetadataRequestTimeoutMs('9');
-    }
-
-    public function testSetMetadataRefreshIntervalMs(): void
-    {
-        $this->config->setMetadataRefreshIntervalMs(1011);
-
-        self::assertSame($this->config->getMetadataRefreshIntervalMs(), 1011);
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set metadata refresh interval value is invalid, must set it 10 .. 3600000
-     */
-    public function testSetMetadataRefreshIntervalMsInvalid(): void
-    {
-        $this->config->setMetadataRefreshIntervalMs('9');
-    }
-
-    public function testSetMetadataMaxAgeMs(): void
-    {
-        $this->config->setMetadataMaxAgeMs(1011);
-
-        self::assertSame($this->config->getMetadataMaxAgeMs(), 1011);
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set metadata max age value is invalid, must set it 1 .. 86400000
-     */
-    public function testSetMetadataMaxAgeMsInvalid(): void
-    {
-        $this->config->setMetadataMaxAgeMs('86400001');
+        $this->config->setConsumeMode(100);
     }
 }

--- a/tests/Base/ConsumerConfigTest.php
+++ b/tests/Base/ConsumerConfigTest.php
@@ -3,8 +3,9 @@
 namespace KafkaTest\Base;
 
 use Kafka\ConsumerConfig;
+use PHPUnit\Framework\TestCase;
 
-final class ConsumerConfigTest extends \PHPUnit\Framework\TestCase
+final class ConsumerConfigTest extends TestCase
 {
     /**
      * @var ConsumerConfig

--- a/tests/Base/ConsumerConfigTest.php
+++ b/tests/Base/ConsumerConfigTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Base;
 
@@ -153,7 +154,7 @@ final class ConsumerConfigTest extends TestCase
      */
     public function testSetSessionTimeoutInvalid(): void
     {
-        $this->config->setSessionTimeout('-1');
+        $this->config->setSessionTimeout(-1);
     }
 
     public function testSetRebalanceTimeout(): void
@@ -169,7 +170,7 @@ final class ConsumerConfigTest extends TestCase
      */
     public function testSetRebalanceTimeoutInvalid(): void
     {
-        $this->config->setRebalanceTimeout('-1');
+        $this->config->setRebalanceTimeout(-1);
     }
 
     public function testSetOffsetReset(): void

--- a/tests/Base/ConsumerTest.php
+++ b/tests/Base/ConsumerTest.php
@@ -20,7 +20,6 @@ final class ConsumerTest extends TestCase
      */
     public function createConsumer(?Consumer\StopStrategy $stopStrategy = null): void
     {
-
         $this->consumer = $this->getMockBuilder(Consumer::class)
                                ->disableOriginalClone()
                                ->disableArgumentCloning()

--- a/tests/Base/ConsumerTest.php
+++ b/tests/Base/ConsumerTest.php
@@ -37,10 +37,10 @@ final class ConsumerTest extends TestCase
     {
         $executed = false;
 
-        $callback = function () {
+        $callback = function (): void {
         };
 
-        $startCallback = function () use (&$executed) {
+        $startCallback = function () use (&$executed): void {
             $executed = true;
             Loop::stop();
         };
@@ -60,10 +60,10 @@ final class ConsumerTest extends TestCase
      */
     public function startShouldLogErrorWhenSomeoneTriesToDoItTwice(): void
     {
-        $callback = function () {
+        $callback = function (): void {
         };
 
-        $startCallback = function () {
+        $startCallback = function (): void {
             $this->consumer->start();
             Loop::stop();
         };
@@ -87,10 +87,10 @@ final class ConsumerTest extends TestCase
     {
         $executed = false;
 
-        $callback = function () {
+        $callback = function (): void {
         };
 
-        $startCallback = function () use (&$executed) {
+        $startCallback = function () use (&$executed): void {
             $executed = true;
         };
 
@@ -117,10 +117,10 @@ final class ConsumerTest extends TestCase
      */
     public function stopShouldCleanThingsAndStopTheLoop(): void
     {
-        $callback = function () {
+        $callback = function (): void {
         };
 
-        $startCallback = function () {
+        $startCallback = function (): void {
             $this->consumer->stop();
         };
 
@@ -149,7 +149,7 @@ final class ConsumerTest extends TestCase
         $process = $this->createMock(Consumer\Process::class);
 
         $process->method('start')->willReturnCallback(
-            function () use ($startCallback) {
+            function () use ($startCallback): void {
                 Loop::defer($startCallback);
             }
         );

--- a/tests/Base/ConsumerTest.php
+++ b/tests/Base/ConsumerTest.php
@@ -6,8 +6,9 @@ namespace KafkaTest\Base;
 use Amp\Loop;
 use Kafka\Consumer;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-final class ConsumerTest extends \PHPUnit\Framework\TestCase
+final class ConsumerTest extends TestCase
 {
     /**
      * @var Consumer|MockObject

--- a/tests/Base/ProducerConfigTest.php
+++ b/tests/Base/ProducerConfigTest.php
@@ -5,8 +5,9 @@ namespace KafkaTest\Base;
 use Kafka\Config;
 use Kafka\ProducerConfig;
 use Kafka\Protocol\Produce;
+use PHPUnit\Framework\TestCase;
 
-final class ProducerConfigTest extends \PHPUnit\Framework\TestCase
+final class ProducerConfigTest extends TestCase
 {
     /**
      * @var ProducerConfig

--- a/tests/Base/ProducerConfigTest.php
+++ b/tests/Base/ProducerConfigTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace KafkaTest\Base;
 
-use Kafka\Config;
+use Kafka\Exception\Config;
 use Kafka\ProducerConfig;
 use Kafka\Protocol\Produce;
 use PHPUnit\Framework\TestCase;
@@ -102,117 +102,6 @@ final class ProducerConfigTest extends TestCase
     }
 
     /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set ssl local cert file is invalid
-     */
-    public function testSetSslLocalCert(): void
-    {
-        $this->config->setSslLocalCert('invalid_path');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set ssl local cert file is invalid
-     */
-    public function testSetSslLocalCertNotFile(): void
-    {
-        $this->config->setSslLocalCert('/tmp');
-    }
-
-    public function testSetSslLocalCertValid(): void
-    {
-        $path = '/etc/passwd';
-        $this->config->setSslLocalCert($path);
-
-        self::assertSame($path, $this->config->getSslLocalCert());
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set ssl local private key file is invalid
-     */
-    public function testSetSslLocalPk(): void
-    {
-        $this->config->setSslLocalPk('invalid_path');
-    }
-
-    public function testSetSslLocalPkValid(): void
-    {
-        $path = '/etc/passwd';
-        $this->config->setSslLocalPk($path);
-
-        self::assertSame($path, $this->config->getSslLocalPk());
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set ssl ca file is invalid
-     */
-    public function testSetSslCafile(): void
-    {
-        $this->config->setSslCafile('invalid_path');
-    }
-
-    public function testSetSslCafileValid(): void
-    {
-        $path = '/etc/passwd';
-        $this->config->setSslCafile($path);
-
-        self::assertSame($path, $this->config->getSslCafile());
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set sasl gssapi keytab file is invalid
-     */
-    public function testSetSaslKeytab(): void
-    {
-        $this->config->setSaslKeytab('invalid_path');
-    }
-
-    public function testSetSaslKeytabValid(): void
-    {
-        $path = '/etc/passwd';
-        $this->config->setSaslKeytab($path);
-
-        self::assertSame($path, $this->config->getSaslKeytab());
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Invalid security protocol given.
-     */
-    public function testSetSecurityProtocol(): void
-    {
-        $this->config->setSecurityProtocol('xxxx');
-    }
-
-    public function testSetSecurityProtocolValid(): void
-    {
-        $protocol = Config::SECURITY_PROTOCOL_PLAINTEXT;
-        $this->config->setSecurityProtocol($protocol);
-
-        self::assertSame($protocol, $this->config->getSecurityProtocol());
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Invalid security sasl mechanism given.
-     */
-    public function testSetSaslMechanism(): void
-    {
-        $this->config->setSaslMechanism('xxxx');
-    }
-
-    public function testSetSaslMechanismValid(): void
-    {
-        $mechanism = Config::SASL_MECHANISMS_GSSAPI;
-        $this->config->setSaslMechanism($mechanism);
-
-        self::assertSame($mechanism, $this->config->getSaslMechanism());
-    }
-
-    /**
      * @test
      */
     public function defaultValueForCompressionIsNull(): void
@@ -240,13 +129,13 @@ final class ProducerConfigTest extends TestCase
         self::assertSame(Produce::COMPRESSION_GZIP, $this->config->getCompression());
     }
 
-    public function testClear(): void
+    /**
+     * @test
+     */
+    public function setCompressionShouldRaiseExceptionWhenInvalidDataIsGiven(): void
     {
-        $mechanism = Config::SASL_MECHANISMS_GSSAPI;
-        $this->config->setSaslMechanism($mechanism);
-        self::assertSame($mechanism, $this->config->getSaslMechanism());
-        $this->config->clear();
+        $this->expectException(Config::class);
 
-        self::assertSame(Config::SASL_MECHANISMS_PLAIN, $this->config->getSaslMechanism());
+        $this->config->setCompression(123);
     }
 }

--- a/tests/Base/ProducerConfigTest.php
+++ b/tests/Base/ProducerConfigTest.php
@@ -102,15 +102,6 @@ final class ProducerConfigTest extends TestCase
 
     /**
      * @expectedException \Kafka\Exception\Config
-     * @expectedExceptionMessage Set isAsyn value is invalid, must set it bool value
-     */
-    public function testSetIsAsynValid(): void
-    {
-        $this->config->setIsAsyn('-2');
-    }
-
-    /**
-     * @expectedException \Kafka\Exception\Config
      * @expectedExceptionMessage Set ssl local cert file is invalid
      */
     public function testSetSslLocalCert(): void

--- a/tests/Base/ProducerConfigTest.php
+++ b/tests/Base/ProducerConfigTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Base;
 
@@ -43,7 +44,7 @@ final class ProducerConfigTest extends TestCase
      */
     public function testSetRequestTimeoutValid(): void
     {
-        $this->config->setRequestTimeout('-1');
+        $this->config->setRequestTimeout(-1);
     }
 
     public function testSetProduceInterval(): void
@@ -59,7 +60,7 @@ final class ProducerConfigTest extends TestCase
      */
     public function testSetProduceIntervalValid(): void
     {
-        $this->config->setProduceInterval('-1');
+        $this->config->setProduceInterval(-1);
     }
 
     public function testSetTimeout(): void
@@ -75,7 +76,7 @@ final class ProducerConfigTest extends TestCase
      */
     public function testSetTimeoutValid(): void
     {
-        $this->config->setTimeout('-1');
+        $this->config->setTimeout(-1);
     }
 
     public function testSetRequiredAck(): void
@@ -90,7 +91,7 @@ final class ProducerConfigTest extends TestCase
      */
     public function testSetRequiredAckValid(): void
     {
-        $this->config->setRequiredAck('-2');
+        $this->config->setRequiredAck(-2);
     }
 
     public function testSetIsAsyn(): void

--- a/tests/Base/ProtocolTest.php
+++ b/tests/Base/ProtocolTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Base;
 
 use Kafka\Protocol;

--- a/tests/Base/ProtocolTest.php
+++ b/tests/Base/ProtocolTest.php
@@ -69,6 +69,9 @@ class ProtocolTest extends TestCase
         self::assertSame($message, Protocol::getError($errorCode));
     }
 
+    /**
+     * @return int&string[]
+     */
     public function errorCodesAndExpectedMessages(): array
     {
         return [

--- a/tests/Base/ProtocolTest.php
+++ b/tests/Base/ProtocolTest.php
@@ -58,7 +58,7 @@ class ProtocolTest extends TestCase
 
         $test = Protocol::decode(Protocol::HEART_BEAT_REQUEST, \hex2bin('0000'));
 
-        self::assertJsonStringEqualsJsonString('{"errorCode":0}', json_encode($test));
+        self::assertJsonStringEqualsJsonString('{"errorCode":0}', \json_encode($test));
     }
 
     /**

--- a/tests/Base/ProtocolTest.php
+++ b/tests/Base/ProtocolTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Base;
 
 use Kafka\Protocol;
+use PHPUnit\Framework\TestCase;
 
-class ProtocolTest extends \PHPUnit\Framework\TestCase
+class ProtocolTest extends TestCase
 {
     public function testEncode(): void
     {

--- a/tests/Base/Sasl/GssapiTest.php
+++ b/tests/Base/Sasl/GssapiTest.php
@@ -3,11 +3,13 @@ namespace KafkaTest\Base\Sasl;
 
 use Kafka\Sasl\Gssapi;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Kafka\Socket;
 
 /**
  * @requires extension krb5 1.1.2
  */
-class GssapiTest extends \PHPUnit\Framework\TestCase
+class GssapiTest extends TestCase
 {
     private $root;
 
@@ -89,7 +91,7 @@ class GssapiTest extends \PHPUnit\Framework\TestCase
 
     private function getSocketForTestGssapi($writeTimes = 3)
     {
-        $socket        = $this->createMock(\Kafka\Socket::class);
+        $socket        = $this->createMock(Socket::class);
         $handShakeData = \hex2bin('00000011000000000004000d534352414d2d5348412d3531320005504c41494e0006475353415049000d534352414d2d5348412d323536');
         $stokenLength  = \hex2bin('00000020');
         $stokenData    = \hex2bin('050401ff000c0000000000003661d1c10101000011e9d2da795b1800cdf2ffc7');

--- a/tests/Base/Sasl/GssapiTest.php
+++ b/tests/Base/Sasl/GssapiTest.php
@@ -117,7 +117,7 @@ class GssapiTest extends TestCase
         return $socket;
     }
 
-    private function mockGssapiContext(string $principal, bool $success = true, int $initTimes = 1, int $wrapTimes = 1) : \GSSAPIContext
+    private function mockGssapiContext(string $principal, bool $success = true, int $initTimes = 1, int $wrapTimes = 1): \GSSAPIContext
     {
         $gssapiContext = $this->createMock(\GSSAPIContext::class);
         $gssapiContext->expects($this->exactly($initTimes))

--- a/tests/Base/Sasl/GssapiTest.php
+++ b/tests/Base/Sasl/GssapiTest.php
@@ -2,29 +2,27 @@
 namespace KafkaTest\Base\Sasl;
 
 use Kafka\Sasl\Gssapi;
-use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Kafka\Socket;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @requires extension krb5 1.1.2
  */
 class GssapiTest extends TestCase
 {
+    /**
+     * @var vfsStreamDirectory
+     */
     private $root;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->root = vfsStream::setup('test', 0777, ['keytab' => 'testdata']);
     }
 
-    /**
-     * testGssapi
-     *
-     * @access public
-     * @return void
-     */
-    public function testGssapi()
+    public function testGssapi(): void
     {
         $principal    = 'testprincipal';
         $socket       = $this->getSocketForTestGssapi();
@@ -33,40 +31,26 @@ class GssapiTest extends TestCase
     }
 
     /**
-     * testKeytabIsNotExists
-     *
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Invalid keytab, keytab file not exists.
-     * @access public
-     * @return void
      */
-    public function testKeytabIsNotExists()
+    public function testKeytabIsNotExists(): void
     {
         Gssapi::fromKeytab($this->root->url() . '/rand', 'testprincipal');
     }
 
     /**
-     * testKeytabIsNotReadable
-     *
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Invalid keytab, keytab file disable read.
-     * @access public
-     * @return void
      */
-    public function testKeytabIsNotReadable()
+    public function testKeytabIsNotReadable(): void
     {
         $keytab = $this->root->url() . '/keytab';
         chmod($keytab, 0000);
         Gssapi::fromKeytab($keytab, 'testprincipal');
     }
 
-    /**
-     * testGetMechanismName
-     *
-     * @access public
-     * @return void
-     */
-    public function testGetMechanismName()
+    public function testGetMechanismName(): void
     {
         $principal    = 'testprincipal';
         $saslProvider = new Gssapi($this->mockGssapiContext($principal, false, 0, 0), $principal);
@@ -74,14 +58,10 @@ class GssapiTest extends TestCase
     }
 
     /**
-     * testInitSecurityContext
-     *
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Init security context failure.
-     * @access public
-     * @return void
      */
-    public function testInitSecurityContextNotSuccess()
+    public function testInitSecurityContextNotSuccess(): void
     {
         $principal    = 'testprincipal';
         $socket       = $this->getSocketForTestGssapi(1);
@@ -89,7 +69,7 @@ class GssapiTest extends TestCase
         $saslProvider->authenticate($socket);
     }
 
-    private function getSocketForTestGssapi($writeTimes = 3)
+    private function getSocketForTestGssapi(int $writeTimes = 3): Socket
     {
         $socket        = $this->createMock(Socket::class);
         $handShakeData = \hex2bin('00000011000000000004000d534352414d2d5348412d3531320005504c41494e0006475353415049000d534352414d2d5348412d323536');
@@ -119,27 +99,32 @@ class GssapiTest extends TestCase
 
     private function mockGssapiContext(string $principal, bool $success = true, int $initTimes = 1, int $wrapTimes = 1): \GSSAPIContext
     {
-        $gssapiContext = $this->createMock(\GSSAPIContext::class);
-        $gssapiContext->expects($this->exactly($initTimes))
-                      ->method('initSecContext')
-                    ->with(
-                        $this->equalTo($principal),
-                        $this->isNull(),
-                        $this->isNull(),
-                        $this->isNull(),
-                        $this->equalTo('')
-                    )
-                      ->will($this->returnCallback(function ($principal, $input, $flag, $time, &$token) use ($success) {
-                            $token = \hex2bin('6082024e06092a864886f71201020201006e82023d30820239a003020105a10302010ea20703050000000000a3820147618201433082013fa003020105a1101b0e4e4d5245444b41464b412e434f4da2193017a003020101a110300e1b056b61666b611b056e6f646531a382010930820105a003020112a103020102a281f80481f597006a24dff024c2bdce31208d10baf56f5d350701c4b67cc51f49cab447d5e472a68dfc00f8cf224f5c2bfb32cd2e22eb02f36ede0200288c97812668370ee4770ff7d8b3bd0e5317c5c03e16b9b15c6a3e74278486ca8a5fc6662d0423d20db556bd57cf6666146ac8e947add40bbfa0d95fed9f028b693a826b707b70d4570b86ac5b608f2e11148c7f7d16136581c02021cb4a33716351ad49835d0ff42335c8e468be49599ec3c4885a91a0957d03163bdc602f5727eefb5c349a9c4108a7b45f82c1daba5eb422f28e99b9488078cf126097077187cca19d2b9938bf13f70ecbc32f69dd694ace256f5bf4553853a91cb91ca481d83081d5a003020112a281cd0481ca3a4b55c8b95e41b8337e0f95d2b26289ce3db0793d0345961271bb3c7beff0f2a354110c5e6edab02b932568baa19ba340b811aca8a0e7e750962f2d2bf8d2144d7e9de9f3826daaa11d9a4a2f0b8880f5b3ab924b4a6e6f8b93a92d54fc085f9f921c8b98487942f29724457407f94f9b010fff2928b04e648fcd13b830417db3f9ae1cc13c03d6b0d660ceba0730f00ea161a7a83141a56e19734dee2825952e7fc6a03b8bf3eee5693b99ac63d34bd4593dfdecb29628d4d54eb343a43c95637595e56fbd1bcacab4');
-                            return $success;
-                      }));
-        $stoken = \hex2bin('050401ff000c0000000000003661d1c10101000011e9d2da795b1800cdf2ffc7');
-        $gssapiContext->expects($this->exactly($wrapTimes))
-                      ->method('wrap')
-                      ->with($this->equalTo($stoken))
-                      ->will($this->returnCallback(function ($token, &$message) {
-                        $message = \hex2bin('050400ff000c0000000000003661d1c1050401ff000c0000000000003661d1c10101000011e9d2da795b1800cdf2ffc79eccf0bb0e3a15a5164711a0');
-                      }));
-        return $gssapiContext;
+        $initCallback = function ($principal, $input, $flag, $time, &$token) use ($success): bool {
+            $token = \hex2bin(
+                '6082024e06092a864886f71201020201006e82023d30820239a003020105a10302010ea20703050000000000a3820147618201433082013fa003020105a1101b0e4e4d5245444b41464b412e434f4da2193017a003020101a110300e1b056b61666b611b056e6f646531a382010930820105a003020112a103020102a281f80481f597006a24dff024c2bdce31208d10baf56f5d350701c4b67cc51f49cab447d5e472a68dfc00f8cf224f5c2bfb32cd2e22eb02f36ede0200288c97812668370ee4770ff7d8b3bd0e5317c5c03e16b9b15c6a3e74278486ca8a5fc6662d0423d20db556bd57cf6666146ac8e947add40bbfa0d95fed9f028b693a826b707b70d4570b86ac5b608f2e11148c7f7d16136581c02021cb4a33716351ad49835d0ff42335c8e468be49599ec3c4885a91a0957d03163bdc602f5727eefb5c349a9c4108a7b45f82c1daba5eb422f28e99b9488078cf126097077187cca19d2b9938bf13f70ecbc32f69dd694ace256f5bf4553853a91cb91ca481d83081d5a003020112a281cd0481ca3a4b55c8b95e41b8337e0f95d2b26289ce3db0793d0345961271bb3c7beff0f2a354110c5e6edab02b932568baa19ba340b811aca8a0e7e750962f2d2bf8d2144d7e9de9f3826daaa11d9a4a2f0b8880f5b3ab924b4a6e6f8b93a92d54fc085f9f921c8b98487942f29724457407f94f9b010fff2928b04e648fcd13b830417db3f9ae1cc13c03d6b0d660ceba0730f00ea161a7a83141a56e19734dee2825952e7fc6a03b8bf3eee5693b99ac63d34bd4593dfdecb29628d4d54eb343a43c95637595e56fbd1bcacab4'
+            );
+
+            return $success;
+        };
+
+        $wrapCallback = function ($token, &$message): void {
+            $message = \hex2bin(
+                '050400ff000c0000000000003661d1c1050401ff000c0000000000003661d1c10101000011e9d2da795b1800cdf2ffc79eccf0bb0e3a15a5164711a0'
+            );
+        };
+
+        $context = $this->createMock(\GSSAPIContext::class);
+
+        $context->expects($this->exactly($initTimes))
+                ->method('initSecContext')
+                ->with($principal, null, null, null, '')
+                ->willReturnCallback($initCallback);
+
+        $context->expects($this->exactly($wrapTimes))
+                ->method('wrap')
+                ->with(\hex2bin('050401ff000c0000000000003661d1c10101000011e9d2da795b1800cdf2ffc7'))
+                ->willReturnCallback($wrapCallback);
+
+        return $context;
     }
 }

--- a/tests/Base/Sasl/GssapiTest.php
+++ b/tests/Base/Sasl/GssapiTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace KafkaTest\Base\Sasl;
 
-use \Kafka\Sasl\Gssapi;
+use Kafka\Sasl\Gssapi;
 use org\bovigo\vfs\vfsStream;
 
 /**

--- a/tests/Base/Sasl/GssapiTest.php
+++ b/tests/Base/Sasl/GssapiTest.php
@@ -48,7 +48,7 @@ class GssapiTest extends TestCase
     public function testKeytabIsNotReadable(): void
     {
         $keytab = $this->root->url() . '/keytab';
-        chmod($keytab, 0000);
+        \chmod($keytab, 0000);
         Gssapi::fromKeytab($keytab, 'testprincipal');
     }
 

--- a/tests/Base/Sasl/GssapiTest.php
+++ b/tests/Base/Sasl/GssapiTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Base\Sasl;
 
 use Kafka\Sasl\Gssapi;

--- a/tests/Base/Sasl/PlainTest.php
+++ b/tests/Base/Sasl/PlainTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace KafkaTest\Base\Sasl;
 
-use PHPUnit\Framework\TestCase;
-use Kafka\Socket;
 use Kafka\Sasl\Plain;
+use Kafka\Socket;
+use PHPUnit\Framework\TestCase;
 
 class PlainTest extends TestCase
 {

--- a/tests/Base/Sasl/PlainTest.php
+++ b/tests/Base/Sasl/PlainTest.php
@@ -1,7 +1,11 @@
 <?php
 namespace KafkaTest\Base\Sasl;
 
-class PlainTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use Kafka\Socket;
+use Kafka\Sasl\Plain;
+
+class PlainTest extends TestCase
 {
 
     /**
@@ -13,7 +17,7 @@ class PlainTest extends \PHPUnit\Framework\TestCase
     public function testHandShake()
     {
         // Create a stub for the SomeClass class.
-        $socket = $this->createMock(\Kafka\Socket::class);
+        $socket = $this->createMock(Socket::class);
 
         $handShakeData = \hex2bin('00000011000000000004000d534352414d2d5348412d3531320005504c41494e0006475353415049000d534352414d2d5348412d323536');
         // Configure the stub.
@@ -26,7 +30,7 @@ class PlainTest extends \PHPUnit\Framework\TestCase
                 [$this->equalTo(\hex2bin('0000000d006e6d72656400313233343536'))]
             );
 
-        $provider = new \Kafka\Sasl\Plain('nmred', '123456');
+        $provider = new Plain('nmred', '123456');
         $provider->authenticate($socket);
     }
 

--- a/tests/Base/Sasl/PlainTest.php
+++ b/tests/Base/Sasl/PlainTest.php
@@ -11,9 +11,8 @@ class PlainTest extends TestCase
      * testHandShake
      *
      * @access public
-     * @return void
      */
-    public function testHandShake()
+    public function testHandShake(): void
     {
         // Create a stub for the SomeClass class.
         $socket = $this->createMock(Socket::class);
@@ -39,9 +38,8 @@ class PlainTest extends TestCase
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage The broker does not support the requested SASL mechanism.
      * @access public
-     * @return void
      */
-    public function testHandShakeNotSupport()
+    public function testHandShakeNotSupport(): void
     {
         // Create a stub for the SomeClass class.
         $socket = $this->createMock(\Kafka\Socket::class);
@@ -64,9 +62,8 @@ class PlainTest extends TestCase
      * testGetMechanismName
      *
      * @access public
-     * @return void
      */
-    public function testGetMechanismName()
+    public function testGetMechanismName(): void
     {
         $provider = new \Kafka\Sasl\Plain('nmred', '123456');
         $this->assertSame('PLAIN', $provider->getName());

--- a/tests/Base/Sasl/PlainTest.php
+++ b/tests/Base/Sasl/PlainTest.php
@@ -7,7 +7,6 @@ use Kafka\Sasl\Plain;
 
 class PlainTest extends TestCase
 {
-
     /**
      * testHandShake
      *

--- a/tests/Base/Sasl/PlainTest.php
+++ b/tests/Base/Sasl/PlainTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Base\Sasl;
 
 use Kafka\Sasl\Plain;

--- a/tests/Base/Sasl/ScramTest.php
+++ b/tests/Base/Sasl/ScramTest.php
@@ -7,7 +7,6 @@ use Kafka\Socket;
 
 class ScramTest extends TestCase
 {
-
     /**
      * testScram
      *

--- a/tests/Base/Sasl/ScramTest.php
+++ b/tests/Base/Sasl/ScramTest.php
@@ -2,8 +2,10 @@
 namespace KafkaTest\Base\Sasl;
 
 use Kafka\Sasl\Scram;
+use PHPUnit\Framework\TestCase;
+use Kafka\Socket;
 
-class ScramTest extends \PHPUnit\Framework\TestCase
+class ScramTest extends TestCase
 {
 
     /**
@@ -112,7 +114,7 @@ class ScramTest extends \PHPUnit\Framework\TestCase
 
     private function getSocketForVerify(string $verifyMessage = '')
     {
-        $socket             = $this->createMock(\Kafka\Socket::class);
+        $socket             = $this->createMock(Socket::class);
         $handShakeData      = \hex2bin('00000011000000000004000d534352414d2d5348412d3531320005504c41494e0006475353415049000d534352414d2d5348412d323536');
         $firstServerMessage = 'r=5Fr49BaTHKn0i9ytDBMw8YXNMOemtxbJ+opDL/miWK8=ou7tesfefbqo5ymk9dajioxiv,s=a3Vqa3JvOGRldzVpbWNxY3QwMXdzZW0yYg==,i=8192';
         $verifyMessage      = ($verifyMessage === '') ? 'v=AM496N+dPKeXeORuChQslmlCo+QHI8wy7CxRWOIMXdY=' : $verifyMessage;

--- a/tests/Base/Sasl/ScramTest.php
+++ b/tests/Base/Sasl/ScramTest.php
@@ -11,9 +11,8 @@ class ScramTest extends TestCase
      * testScram
      *
      * @access public
-     * @return void
      */
-    public function testScram()
+    public function testScram(): void
     {
         $provider = $this->getMockBuilder(Scram::class)
             ->setMethods(['generateNonce'])
@@ -31,9 +30,8 @@ class ScramTest extends TestCase
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Verify server final response message is failure
      * @access public
-     * @return void
      */
-    public function testScramVerify()
+    public function testScramVerify(): void
     {
         $provider = $this->getMockBuilder(Scram::class)
             ->setMethods(['generateNonce'])
@@ -51,9 +49,8 @@ class ScramTest extends TestCase
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Server response challenge is invalid.
      * @access public
-     * @return void
      */
-    public function testFinalMessageInvalid()
+    public function testFinalMessageInvalid(): void
     {
         $this->finalMessage();
     }
@@ -64,9 +61,8 @@ class ScramTest extends TestCase
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Server response challenge is invalid, paser salt is failure.
      * @access public
-     * @return void
      */
-    public function testFinalMessageInvalidSalt()
+    public function testFinalMessageInvalidSalt(): void
     {
         $message = 'r=5Fr49BaTHKn0i9ytDBMw8YXNMOemtxbJ+opDL/miWK8=ou7tesfefbqo5ymk9dajioxiv,s=,i=8192';
         $this->finalMessage($message);
@@ -78,9 +74,8 @@ class ScramTest extends TestCase
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Server response challenge is invalid, cnonce is invalid.
      * @access public
-     * @return void
      */
-    public function testFinalMessageInvalidCnonce()
+    public function testFinalMessageInvalidCnonce(): void
     {
         $message = 'r=59BaTHKn0i9ytDBMw8YXNMOemtxbJ+opDL/miWK8=ou7tesfefbqo5ymk9dajioxiv,s=a3Vqa3JvOGRldzVpbWNxY3QwMXdzZW0yYg==,i=8192';
         $this->finalMessage($message);
@@ -92,9 +87,8 @@ class ScramTest extends TestCase
      * @expectedException \Kafka\Exception
      * @expectedExceptionMessage Invalid hash algorithm given, it must be one of: [SCRAM_SHA_256, SCRAM_SHA_512].
      * @access public
-     * @return void
      */
-    public function testInvalidAlgorithm()
+    public function testInvalidAlgorithm(): void
     {
         new Scram('nmred', '123456', 64);
     }
@@ -103,15 +97,14 @@ class ScramTest extends TestCase
      * testGetMechanismName
      *
      * @access public
-     * @return void
      */
-    public function testGetMechanismName()
+    public function testGetMechanismName(): void
     {
         $provider = new Scram('nmred', '123456', Scram::SCRAM_SHA_256);
         $this->assertSame('SCRAM-SHA-256', $provider->getName());
     }
 
-    private function getSocketForVerify(string $verifyMessage = '')
+    private function getSocketForVerify(string $verifyMessage = ''): Socket
     {
         $socket             = $this->createMock(Socket::class);
         $handShakeData      = \hex2bin('00000011000000000004000d534352414d2d5348412d3531320005504c41494e0006475353415049000d534352414d2d5348412d323536');
@@ -144,9 +137,9 @@ class ScramTest extends TestCase
         return $socket;
     }
 
-    private function getSocketForInvalidFinalMessage(string $serverMessage = '')
+    private function getSocketForInvalidFinalMessage(string $serverMessage = ''): Socket
     {
-        $socket        = $this->createMock(\Kafka\Socket::class);
+        $socket        = $this->createMock(Socket::class);
         $handShakeData = \hex2bin('00000011000000000004000d534352414d2d5348412d3531320005504c41494e0006475353415049000d534352414d2d5348412d323536');
 
         if ($serverMessage === '') {
@@ -175,7 +168,7 @@ class ScramTest extends TestCase
         return $socket;
     }
 
-    private function finalMessage(string $message = '')
+    private function finalMessage(string $message = ''): void
     {
         $provider = $this->getMockBuilder(Scram::class)
             ->setMethods(['generateNonce', 'verifyMessage'])

--- a/tests/Base/Sasl/ScramTest.php
+++ b/tests/Base/Sasl/ScramTest.php
@@ -2,8 +2,8 @@
 namespace KafkaTest\Base\Sasl;
 
 use Kafka\Sasl\Scram;
-use PHPUnit\Framework\TestCase;
 use Kafka\Socket;
+use PHPUnit\Framework\TestCase;
 
 class ScramTest extends TestCase
 {

--- a/tests/Base/Sasl/ScramTest.php
+++ b/tests/Base/Sasl/ScramTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace KafkaTest\Base\Sasl;
 
-use \Kafka\Sasl\Scram;
+use Kafka\Sasl\Scram;
 
 class ScramTest extends \PHPUnit\Framework\TestCase
 {
@@ -131,7 +131,7 @@ class ScramTest extends \PHPUnit\Framework\TestCase
         $firstMessage = \hex2bin('000000396e2c2c6e3d616c6963652c723d3546723439426154484b6e306939797444424d773859584e4d4f656d7478624a2b6f70444c2f6d69574b383d');
         // final message: c=biws,r=5Fr49BaTHKn0i9ytDBMw8YXNMOemtxbJ+opDL/miWK8=ou7tesfefbqo5ymk9dajioxiv,p=Ky7+xuihooYxDciXZYCr1j54tmc0y/ZvPN8So/1hi/w=
         $finalMessage = \hex2bin('0000007d633d626977732c723d3546723439426154484b6e306939797444424d773859584e4d4f656d7478624a2b6f70444c2f6d69574b383d6f753774657366656662716f35796d6b3964616a696f7869762c703d4b79372b787569686f6f5978446369585a594372316a3534746d6330792f5a76504e38536f2f3168692f773d');
-        
+
         $socket->expects($this->exactly(3))
             ->method('writeBlocking')
             ->withConsecutive(

--- a/tests/Base/Sasl/ScramTest.php
+++ b/tests/Base/Sasl/ScramTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Base\Sasl;
 
 use Kafka\Sasl\Scram;

--- a/tests/Base/SocketTest.php
+++ b/tests/Base/SocketTest.php
@@ -92,7 +92,7 @@ class SocketTest extends TestCase
         $cafile     = $this->root->url() . '/cafile';
         $peerName   = 'kafka';
 
-        $context = stream_context_create(
+        $context = \stream_context_create(
             [
                 'ssl' => [
                     'local_cert'  => $localCert,
@@ -109,7 +109,7 @@ class SocketTest extends TestCase
 
         $streamMock->expects($this->once())
                    ->method('context')
-                   ->with(stream_context_get_options($context));
+                   ->with(\stream_context_get_options($context));
 
         $config = $this->getMockForAbstractClass(Config::class);
         $config->setSslEnable(true);
@@ -311,14 +311,14 @@ class SocketTest extends TestCase
 
     public function testWriteBlockingMaxBuffer(): void
     {
-        $str  = str_pad('', Socket::MAX_WRITE_BUFFER * 2, '*');
+        $str  = \str_pad('', Socket::MAX_WRITE_BUFFER * 2, '*');
         $host = '127.0.0.1';
         $port = 9192;
 
         $streamMock = $this->initStreamStub('tcp', $host, $port);
 
         $streamMock->method('write')
-                   ->withConsecutive([substr($str, 0, Socket::MAX_WRITE_BUFFER)], [substr($str, Socket::MAX_WRITE_BUFFER)])
+                   ->withConsecutive([\substr($str, 0, Socket::MAX_WRITE_BUFFER)], [\substr($str, Socket::MAX_WRITE_BUFFER)])
                    ->willReturnOnConsecutiveCalls(Socket::MAX_WRITE_BUFFER, Socket::MAX_WRITE_BUFFER);
 
         $socket = $this->createStream($host, $port, 1);
@@ -333,14 +333,14 @@ class SocketTest extends TestCase
      */
     public function testWriteBlockingReturnFalse(): void
     {
-        $str  = str_pad('', Socket::MAX_WRITE_BUFFER * 2, '*');
+        $str  = \str_pad('', Socket::MAX_WRITE_BUFFER * 2, '*');
         $host = '127.0.0.1';
         $port = 9192;
 
         $streamMock = $this->initStreamStub('tcp', $host, $port);
 
         $streamMock->method('write')
-                   ->withConsecutive([substr($str, 0, Socket::MAX_WRITE_BUFFER)])
+                   ->withConsecutive([\substr($str, 0, Socket::MAX_WRITE_BUFFER)])
                    ->willReturnOnConsecutiveCalls(0);
 
         $socket = $this->createStream($host, $port, 1);
@@ -382,7 +382,7 @@ class SocketTest extends TestCase
         array $mockMethod = []
     ): Socket {
         $socket = $this->getMockBuilder(Socket::class)
-                       ->setMethods(array_merge(['createSocket'], $mockMethod))
+                       ->setMethods(\array_merge(['createSocket'], $mockMethod))
                        ->setConstructorArgs([$host, $port, $config, $sasl])
                        ->getMock();
 
@@ -392,7 +392,7 @@ class SocketTest extends TestCase
                         $errno  = 99;
                         $errstr = 'my custom error';
 
-                        return @fopen($remoteSocket, 'r+', false, $context);
+                        return @\fopen($remoteSocket, 'r+', false, $context);
                 }
             );
 
@@ -404,8 +404,8 @@ class SocketTest extends TestCase
      */
     private function initStreamStub(string $transport, string $host, int $port, bool $success = true): Stream
     {
-        $uri = sprintf('%s://%s:%s', $transport, $host, $port);
-        stream_wrapper_register($transport, SimpleStream::class);
+        $uri = \sprintf('%s://%s:%s', $transport, $host, $port);
+        \stream_wrapper_register($transport, SimpleStream::class);
 
         $streamMock = $this->createMock(Stream::class);
         $streamMock->method('open')->with($uri, 'r+', 0)->willReturn($success);
@@ -439,12 +439,12 @@ class SocketTest extends TestCase
 
     private function clearStreamMock(): void
     {
-        if (in_array('ssl', stream_get_wrappers(), true)) {
-            stream_wrapper_unregister('ssl');
+        if (\in_array('ssl', \stream_get_wrappers(), true)) {
+            \stream_wrapper_unregister('ssl');
         }
 
-        if (in_array('tcp', stream_get_wrappers(), true)) {
-            stream_wrapper_unregister('tcp');
+        if (\in_array('tcp', \stream_get_wrappers(), true)) {
+            \stream_wrapper_unregister('tcp');
         }
     }
 }

--- a/tests/Base/SocketTest.php
+++ b/tests/Base/SocketTest.php
@@ -7,11 +7,15 @@ use Kafka\Socket;
 use KafkaTest\Base\StreamStub\Simple as SimpleStream;
 use KafkaTest\Base\StreamStub\Stream;
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SocketTest extends TestCase
 {
+    /**
+     * @var vfsStreamDirectory
+     */
     private $root;
 
     public function setUp(): void
@@ -364,10 +368,17 @@ class SocketTest extends TestCase
     }
 
     /**
+     * @param string[] $mockMethod
+     *
      * @return Socket|MockObject
      */
-    private function mockStreamSocketClient($host, $port, $config = null, $sasl = null, $mockMethod = []): Socket
-    {
+    private function mockStreamSocketClient(
+        string $host,
+        int $port,
+        ?Config $config = null,
+        ?SaslMechanism $sasl = null,
+        array $mockMethod = []
+    ): Socket {
         $socket = $this->getMockBuilder(Socket::class)
                        ->setMethods(array_merge(['createSocket'], $mockMethod))
                        ->setConstructorArgs([$host, $port, $config, $sasl])
@@ -404,6 +415,9 @@ class SocketTest extends TestCase
     }
 
     /**
+     * @param int|bool $select
+     * @param mixed[] $metaData
+     *
      * @return Socket|MockObject
      */
     private function createStream(string $host, int $port, $select, array $metaData = []): Socket

--- a/tests/Base/SocketTest.php
+++ b/tests/Base/SocketTest.php
@@ -8,8 +8,9 @@ use KafkaTest\Base\StreamStub\Simple as SimpleStream;
 use KafkaTest\Base\StreamStub\Stream;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class SocketTest extends \PHPUnit\Framework\TestCase
+class SocketTest extends TestCase
 {
     private $root;
 

--- a/tests/Base/SocketTest.php
+++ b/tests/Base/SocketTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Base;
 
 use Kafka\Config;

--- a/tests/Base/SocketTest.php
+++ b/tests/Base/SocketTest.php
@@ -311,7 +311,7 @@ class SocketTest extends TestCase
 
     public function testWriteBlockingMaxBuffer(): void
     {
-        $str  = str_pad('', Socket::MAX_WRITE_BUFFER * 2, "*");
+        $str  = str_pad('', Socket::MAX_WRITE_BUFFER * 2, '*');
         $host = '127.0.0.1';
         $port = 9192;
 
@@ -333,7 +333,7 @@ class SocketTest extends TestCase
      */
     public function testWriteBlockingReturnFalse(): void
     {
-        $str  = str_pad('', Socket::MAX_WRITE_BUFFER * 2, "*");
+        $str  = str_pad('', Socket::MAX_WRITE_BUFFER * 2, '*');
         $host = '127.0.0.1';
         $port = 9192;
 

--- a/tests/Base/StreamStub/Simple.php
+++ b/tests/Base/StreamStub/Simple.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Base\StreamStub;
 

--- a/tests/Base/StreamStub/Simple.php
+++ b/tests/Base/StreamStub/Simple.php
@@ -20,7 +20,7 @@ class Simple
     public function stream_open(string $path, string $mode, int $options): bool
     {
         if (self::$mock !== null) {
-            self::$mock->context(stream_context_get_options($this->context));
+            self::$mock->context(\stream_context_get_options($this->context));
 
             return self::$mock->open($path, $mode, $options);
         }

--- a/tests/Base/StreamStub/Simple.php
+++ b/tests/Base/StreamStub/Simple.php
@@ -3,10 +3,9 @@ namespace KafkaTest\Base\StreamStub;
 
 class Simple
 {
-    
-    public $context = null;
+    public $context;
 
-    protected static $mock = null;
+    protected static $mock;
 
     public function stream_open($path, $mode, $options, &$opened_path)
     {
@@ -14,6 +13,7 @@ class Simple
             self::$mock->context(stream_context_get_options($this->context));
             return self::$mock->open($path, $mode, $options);
         }
+
         return true;
     }
 
@@ -57,7 +57,6 @@ class Simple
         return true;
     }
 
-    
     public static function setMock($mock)
     {
         self::$mock = $mock;

--- a/tests/Base/StreamStub/Simple.php
+++ b/tests/Base/StreamStub/Simple.php
@@ -1,63 +1,87 @@
 <?php
+
 namespace KafkaTest\Base\StreamStub;
+
+use PHPUnit\Framework\MockObject\MockObject;
 
 class Simple
 {
+    /**
+     * @var resource
+     */
     public $context;
 
+    /**
+     * @var Stream|MockObject
+     */
     protected static $mock;
 
-    public function stream_open($path, $mode, $options, &$opened_path)
+    public function stream_open(string $path, string $mode, int $options): bool
     {
         if (self::$mock !== null) {
             self::$mock->context(stream_context_get_options($this->context));
+
             return self::$mock->open($path, $mode, $options);
         }
 
         return true;
     }
 
-    public function stream_eof()
+    public function stream_eof(): bool
     {
         if (self::$mock !== null) {
-            return self::$mock->eof();
+            return self::$mock->eof() ?? false;
         }
+
         return false;
     }
 
-    public function stream_read($len)
+    public function stream_read(int $length): string
     {
         if (self::$mock !== null) {
-            return self::$mock->read($len);
+            return self::$mock->read($length) ?? '';
         }
+
+        return '';
+    }
+
+    public function stream_write(string $data): int
+    {
+        if (self::$mock !== null) {
+            return self::$mock->write($data) ?? 0;
+        }
+
+        return 1;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function stream_metadata(string $path, string $option, $value): bool
+    {
+        if (self::$mock !== null) {
+            return self::$mock->metadata($path, $option, $value);
+        }
+
         return true;
     }
 
-    public function stream_write($data)
+    /**
+     * @param mixed ...$options
+     */
+    public function stream_set_option(...$options): bool
     {
         if (self::$mock !== null) {
-            return self::$mock->write($data);
+            return self::$mock->option(...$options);
         }
+
         return true;
     }
 
-    public function stream_metadata($path, $option, $var)
-    {
-        if (self::$mock !== null) {
-            return self::$mock->metadata($path, $option, $var);
-        }
-        return true;
-    }
-
-    public function stream_set_option($option, $arg1, $arg2)
-    {
-        if (self::$mock !== null) {
-            return self::$mock->option($option, $arg1, $arg2);
-        }
-        return true;
-    }
-
-    public static function setMock($mock)
+    /**
+     * @param Stream|MockObject $mock
+     */
+    public static function setMock(Stream $mock): void
     {
         self::$mock = $mock;
     }

--- a/tests/Base/StreamStub/Stream.php
+++ b/tests/Base/StreamStub/Stream.php
@@ -3,7 +3,6 @@ namespace KafkaTest\Base\StreamStub;
 
 class Stream
 {
-
     public function open($path, $mode, $options)
     {
         return true;

--- a/tests/Base/StreamStub/Stream.php
+++ b/tests/Base/StreamStub/Stream.php
@@ -25,12 +25,12 @@ class Stream
 
     public function read(int $length): string
     {
-        return str_repeat('x', $length);
+        return \str_repeat('x', $length);
     }
 
     public function write(string $data): ?int
     {
-        return strlen($data);
+        return \strlen($data);
     }
 
     /**

--- a/tests/Base/StreamStub/Stream.php
+++ b/tests/Base/StreamStub/Stream.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Base\StreamStub;
 
 class Stream

--- a/tests/Base/StreamStub/Stream.php
+++ b/tests/Base/StreamStub/Stream.php
@@ -3,37 +3,46 @@ namespace KafkaTest\Base\StreamStub;
 
 class Stream
 {
-    public function open($path, $mode, $options)
+    public function open(string $path, string $mode, int $options): bool
     {
         return true;
     }
 
-    public function context($context)
+    /**
+     * @param mixed[] $context
+     */
+    public function context(array $context): bool
     {
         return true;
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return false;
     }
 
-    public function read($length)
+    public function read(int $length): string
     {
-        return false;
+        return str_repeat('x', $length);
     }
 
-    public function write($data)
+    public function write(string $data): ?int
     {
         return strlen($data);
     }
 
-    public function metadata($path, $option, $var)
+    /**
+     * @param mixed $value
+     */
+    public function metadata(string $path, string $option, $value): bool
     {
         return false;
     }
 
-    public function option($option, $args1, $args2)
+    /**
+     * @param mixed ...$options
+     */
+    public function option(...$options): bool
     {
         return true;
     }

--- a/tests/Functional/AsyncProducerTest.php
+++ b/tests/Functional/AsyncProducerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace KafkaTest\Functional;
 
 use Kafka\Protocol;
+use Kafka\Producer;
 
 final class AsyncProducerTest extends ProducerTest
 {
@@ -19,7 +20,7 @@ final class AsyncProducerTest extends ProducerTest
         $messagesSent = false;
         $error        = null;
 
-        $producer = new \Kafka\Producer([$this, 'createMessages']);
+        $producer = new Producer([$this, 'createMessages']);
         $producer->success(
             function (array $response) use (&$messagesSent): void {
                 self::assertNotEmpty($response);

--- a/tests/Functional/AsyncProducerTest.php
+++ b/tests/Functional/AsyncProducerTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace KafkaTest\Functional;
 
-use Kafka\Protocol;
 use Kafka\Producer;
+use Kafka\Protocol;
 
 final class AsyncProducerTest extends ProducerTest
 {

--- a/tests/Functional/ProducerTest.php
+++ b/tests/Functional/ProducerTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace KafkaTest\Functional;
 
+use Kafka\Consumer;
 use Kafka\Consumer\StopStrategy\Callback;
+use Kafka\ConsumerConfig;
+use Kafka\ProducerConfig;
 use Kafka\Protocol\Protocol;
 use PHPUnit\Framework\TestCase;
-use Kafka\ProducerConfig;
-use Kafka\Consumer;
-use Kafka\ConsumerConfig;
 
 abstract class ProducerTest extends TestCase
 {

--- a/tests/Functional/ProducerTest.php
+++ b/tests/Functional/ProducerTest.php
@@ -53,6 +53,7 @@ abstract class ProducerTest extends TestCase
 
     protected function configureProducer(): void
     {
+        /** @var ProducerConfig $config */
         $config = ProducerConfig::getInstance();
         $config->setMetadataBrokerList($this->brokers);
         $config->setBrokerVersion($this->version);
@@ -83,7 +84,7 @@ abstract class ProducerTest extends TestCase
         );
 
         $consumer->start(
-            function (string $topic, int $partition, array $message) use (&$consumedMessages) {
+            function (string $topic, int $partition, array $message) use (&$consumedMessages): void {
                 self::assertSame($this->topic, $topic);
                 self::assertLessThan(3, $partition);
                 self::assertArrayHasKey('offset', $message);
@@ -110,6 +111,7 @@ abstract class ProducerTest extends TestCase
 
     private function configureConsumer(): void
     {
+        /** @var ConsumerConfig $config */
         $config = ConsumerConfig::getInstance();
         $config->setMetadataBrokerList($this->brokers);
         $config->setBrokerVersion($this->version);
@@ -118,6 +120,9 @@ abstract class ProducerTest extends TestCase
         $config->setTopics([$this->topic]);
     }
 
+    /**
+     * @return string[][]
+     */
     public function createMessages(int $amount = self::MESSAGES_TO_SEND): array
     {
         $messages = [];

--- a/tests/Functional/ProducerTest.php
+++ b/tests/Functional/ProducerTest.php
@@ -121,7 +121,7 @@ abstract class ProducerTest extends \PHPUnit\Framework\TestCase
         for ($i = 0; $i < $amount; ++$i) {
             $messages[] = [
                 'topic' => $this->topic,
-                'value' => 'msg-' . str_pad((string) ($i + 1), 2, '0', STR_PAD_LEFT)
+                'value' => 'msg-' . str_pad((string) ($i + 1), 2, '0', STR_PAD_LEFT),
             ];
         }
 

--- a/tests/Functional/ProducerTest.php
+++ b/tests/Functional/ProducerTest.php
@@ -5,8 +5,12 @@ namespace KafkaTest\Functional;
 
 use Kafka\Consumer\StopStrategy\Callback;
 use Kafka\Protocol\Protocol;
+use PHPUnit\Framework\TestCase;
+use Kafka\ProducerConfig;
+use Kafka\Consumer;
+use Kafka\ConsumerConfig;
 
-abstract class ProducerTest extends \PHPUnit\Framework\TestCase
+abstract class ProducerTest extends TestCase
 {
     private const MESSAGES_TO_SEND = 30;
 
@@ -49,7 +53,7 @@ abstract class ProducerTest extends \PHPUnit\Framework\TestCase
 
     protected function configureProducer(): void
     {
-        $config = \Kafka\ProducerConfig::getInstance();
+        $config = ProducerConfig::getInstance();
         $config->setMetadataBrokerList($this->brokers);
         $config->setBrokerVersion($this->version);
 
@@ -70,7 +74,7 @@ abstract class ProducerTest extends \PHPUnit\Framework\TestCase
         $consumedMessages = 0;
         $executionEnd     = new \DateTimeImmutable('+1 minute');
 
-        $consumer = new \Kafka\Consumer(
+        $consumer = new Consumer(
             new Callback(
                 function () use (&$consumedMessages, $executionEnd): bool {
                     return $consumedMessages >= self::MESSAGES_TO_SEND || new \DateTimeImmutable() > $executionEnd;
@@ -106,7 +110,7 @@ abstract class ProducerTest extends \PHPUnit\Framework\TestCase
 
     private function configureConsumer(): void
     {
-        $config = \Kafka\ConsumerConfig::getInstance();
+        $config = ConsumerConfig::getInstance();
         $config->setMetadataBrokerList($this->brokers);
         $config->setBrokerVersion($this->version);
         $config->setGroupId('kafka-php-tests');

--- a/tests/Functional/ProducerTest.php
+++ b/tests/Functional/ProducerTest.php
@@ -39,10 +39,10 @@ abstract class ProducerTest extends TestCase
      */
     public function prepareEnvironment(): void
     {
-        $this->version  = getenv('KAFKA_VERSION');
-        $this->brokers  = getenv('KAFKA_BROKERS');
-        $this->topic    = getenv('KAFKA_TOPIC');
-        $this->compress = getenv('KAFKA_COMPRESS') === '1';
+        $this->version  = \getenv('KAFKA_VERSION');
+        $this->brokers  = \getenv('KAFKA_BROKERS');
+        $this->topic    = \getenv('KAFKA_TOPIC');
+        $this->compress = \getenv('KAFKA_COMPRESS') === '1';
 
         if (! $this->version || ! $this->brokers || ! $this->topic) {
             self::markTestSkipped(
@@ -97,7 +97,7 @@ abstract class ProducerTest extends TestCase
                 self::assertArrayHasKey('value', $message['message']);
                 self::assertContains('msg-', $message['message']['value']);
 
-                if (version_compare($this->version, '0.10.0', '>=')) {
+                if (\version_compare($this->version, '0.10.0', '>=')) {
                     self::assertArrayHasKey('timestamp', $message['message']);
                     self::assertNotEquals(-1, $message['message']['timestamp']);
                 }
@@ -130,7 +130,7 @@ abstract class ProducerTest extends TestCase
         for ($i = 0; $i < $amount; ++$i) {
             $messages[] = [
                 'topic' => $this->topic,
-                'value' => 'msg-' . str_pad((string) ($i + 1), 2, '0', STR_PAD_LEFT),
+                'value' => 'msg-' . \str_pad((string) ($i + 1), 2, '0', \STR_PAD_LEFT),
             ];
         }
 

--- a/tests/Functional/SyncProducerTest.php
+++ b/tests/Functional/SyncProducerTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace KafkaTest\Functional;
 
+use Kafka\Producer;
+
 final class SyncProducerTest extends ProducerTest
 {
     /**
@@ -14,7 +16,7 @@ final class SyncProducerTest extends ProducerTest
     {
         $this->configureProducer();
 
-        $producer = new \Kafka\Producer();
+        $producer = new Producer();
         $messages = $this->createMessages();
 
         foreach ($messages as $message) {

--- a/tests/Protocol/ApiVersionsTest.php
+++ b/tests/Protocol/ApiVersionsTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\ApiVersions;
+use PHPUnit\Framework\TestCase;
 
-final class ApiVersionsTest extends \PHPUnit\Framework\TestCase
+final class ApiVersionsTest extends TestCase
 {
     private $apiVersion;
 

--- a/tests/Protocol/ApiVersionsTest.php
+++ b/tests/Protocol/ApiVersionsTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class ApiVersionsTest extends TestCase
 {
+    /**
+     * @var ApiVersions
+     */
     private $apiVersion;
 
     public function setUp(): void

--- a/tests/Protocol/ApiVersionsTest.php
+++ b/tests/Protocol/ApiVersionsTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\ApiVersions;

--- a/tests/Protocol/ApiVersionsTest.php
+++ b/tests/Protocol/ApiVersionsTest.php
@@ -31,6 +31,6 @@ final class ApiVersionsTest extends TestCase
         $expected = '{"apiVersions":[[0,0,5],[1,0,6],[2,0,2],[3,0,5],[4,0,1],[5,0,0],[6,0,4],[7,0,1],[8,0,3],[9,0,3],[10,0,1],[11,0,2],[12,0,1],[13,0,1],[14,0,1],[15,0,1],[16,0,1],[17,0,1],[18,0,1],[19,0,2],[20,0,1],[21,0,0],[22,0,0],[23,0,0],[24,0,0],[25,0,0],[26,0,0],[27,0,0],[28,0,0],[29,0,0],[30,0,0],[31,0,0],[32,0,0],[33,0,0],[34,0,0],[35,0,0],[36,0,0],[37,0,0]],"errorCode":0}';
 
         $test = $this->apiVersion->decode(\hex2bin($data));
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/CommitOffsetTest.php
+++ b/tests/Protocol/CommitOffsetTest.php
@@ -27,9 +27,9 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
                             'partition' => 0,
                             'offset' => 45,
                             'metadata' => '',
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -50,9 +50,9 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
                         [
                             'partition' => 0,
                             'offset' => 45,
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
         ];
 
@@ -69,7 +69,7 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
     public function testEncodeNoData(): void
     {
         $data = [
-            'group_id' => 'test'
+            'group_id' => 'test',
         ];
 
         $this->commit->encode($data);
@@ -82,7 +82,7 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
     public function testEncodeNoGroupId(): void
     {
         $data = [
-            'data' => []
+            'data' => [],
         ];
 
         $this->commit->encode($data);
@@ -97,7 +97,7 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
         $data = [
             'group_id' => 'test',
             'data' => [
-                []
+                [],
             ],
         ];
 
@@ -115,7 +115,7 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
             'data' => [
                 [
                     'topic_name' => 'test',
-                ]
+                ],
             ],
         ];
 
@@ -134,9 +134,9 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
                 [
                     'topic_name' => 'test',
                     'partitions' => [
-                        []
-                    ]
-                ]
+                        [],
+                    ],
+                ],
             ],
         ];
 
@@ -156,10 +156,10 @@ final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
                     'topic_name' => 'test',
                     'partitions' => [
                         [
-                            'partition' => 0
-                        ]
-                    ]
-                ]
+                            'partition' => 0,
+                        ],
+                    ],
+                ],
             ],
         ];
 

--- a/tests/Protocol/CommitOffsetTest.php
+++ b/tests/Protocol/CommitOffsetTest.php
@@ -74,9 +74,7 @@ final class CommitOffsetTest extends TestCase
      */
     public function testEncodeNoData(): void
     {
-        $data = [
-            'group_id' => 'test',
-        ];
+        $data = ['group_id' => 'test'];
 
         $this->commit->encode($data);
     }
@@ -119,9 +117,7 @@ final class CommitOffsetTest extends TestCase
         $data = [
             'group_id' => 'test',
             'data' => [
-                [
-                    'topic_name' => 'test',
-                ],
+                ['topic_name' => 'test'],
             ],
         ];
 
@@ -161,9 +157,7 @@ final class CommitOffsetTest extends TestCase
                 [
                     'topic_name' => 'test',
                     'partitions' => [
-                        [
-                            'partition' => 0,
-                        ],
+                        ['partition' => 0],
                     ],
                 ],
             ],

--- a/tests/Protocol/CommitOffsetTest.php
+++ b/tests/Protocol/CommitOffsetTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class CommitOffsetTest extends TestCase
 {
+    /**
+     * @var CommitOffset
+     */
     private $commit;
 
     public function setUp(): void

--- a/tests/Protocol/CommitOffsetTest.php
+++ b/tests/Protocol/CommitOffsetTest.php
@@ -172,6 +172,6 @@ final class CommitOffsetTest extends TestCase
         $expected = '[{"topicName":"test","partitions":[{"partition":0,"errorCode":0}]}]';
 
         $test = $this->commit->decode(\hex2bin($data));
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/CommitOffsetTest.php
+++ b/tests/Protocol/CommitOffsetTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\CommitOffset;
+use PHPUnit\Framework\TestCase;
 
-final class CommitOffsetTest extends \PHPUnit\Framework\TestCase
+final class CommitOffsetTest extends TestCase
 {
     private $commit;
 

--- a/tests/Protocol/CommitOffsetTest.php
+++ b/tests/Protocol/CommitOffsetTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\CommitOffset;

--- a/tests/Protocol/DescribeGroupsTest.php
+++ b/tests/Protocol/DescribeGroupsTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\DescribeGroups;

--- a/tests/Protocol/DescribeGroupsTest.php
+++ b/tests/Protocol/DescribeGroupsTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class DescribeGroupsTest extends TestCase
 {
+    /**
+     * @var DescribeGroups
+     */
     private $describe;
 
     public function setUp(): void

--- a/tests/Protocol/DescribeGroupsTest.php
+++ b/tests/Protocol/DescribeGroupsTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\DescribeGroups;
+use PHPUnit\Framework\TestCase;
 
-final class DescribeGroupsTest extends \PHPUnit\Framework\TestCase
+final class DescribeGroupsTest extends TestCase
 {
     private $describe;
 

--- a/tests/Protocol/DescribeGroupsTest.php
+++ b/tests/Protocol/DescribeGroupsTest.php
@@ -40,6 +40,6 @@ final class DescribeGroupsTest extends TestCase
         $expected = '[{"errorCode":0,"groupId":"test","state":"Stable","protocolType":"consumer","protocol":"group","members":[{"memberId":"kafka-php-4da393fb-37cf-42cc-90dd-7bf6ba31fd30","clientId":"kafka-php","clientHost":"\/127.0.0.1","metadata":{"version":0,"topics":["test"],"userData":""},"assignment":{"version":0,"partitions":[{"topicName":"test","partitions":[0]}],"userData":""}}]}]';
 
         $test = $this->describe->decode(\hex2bin($data));
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/FetchOffsetTest.php
+++ b/tests/Protocol/FetchOffsetTest.php
@@ -19,8 +19,8 @@ final class FetchOffsetTest extends \PHPUnit\Framework\TestCase
             'data' => [
                 [
                     'topic_name' => 'test',
-                    'partitions' => [0]
-                ]
+                    'partitions' => [0],
+                ],
             ],
         ];
 
@@ -46,7 +46,7 @@ final class FetchOffsetTest extends \PHPUnit\Framework\TestCase
     public function testEncodeNoGroupId(): void
     {
         $data = [
-            'data' => []
+            'data' => [],
         ];
 
         $this->offset->encode($data);
@@ -61,7 +61,7 @@ final class FetchOffsetTest extends \PHPUnit\Framework\TestCase
         $data = [
             'group_id' => 'test',
             'data' => [
-                []
+                [],
             ],
         ];
 
@@ -79,7 +79,7 @@ final class FetchOffsetTest extends \PHPUnit\Framework\TestCase
             'data' => [
                 [
                     'topic_name' => 'test',
-                ]
+                ],
             ],
         ];
 

--- a/tests/Protocol/FetchOffsetTest.php
+++ b/tests/Protocol/FetchOffsetTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\FetchOffset;

--- a/tests/Protocol/FetchOffsetTest.php
+++ b/tests/Protocol/FetchOffsetTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class FetchOffsetTest extends TestCase
 {
+    /**
+     * @var FetchOffset
+     */
     private $offset;
 
     public function setUp(): void
@@ -91,7 +94,6 @@ final class FetchOffsetTest extends TestCase
      * testDecode
      *
      * @access public
-     * @return void
      */
     public function testDecode(): void
     {

--- a/tests/Protocol/FetchOffsetTest.php
+++ b/tests/Protocol/FetchOffsetTest.php
@@ -83,9 +83,7 @@ final class FetchOffsetTest extends TestCase
         $data = [
             'group_id' => 'test',
             'data' => [
-                [
-                    'topic_name' => 'test',
-                ],
+                ['topic_name' => 'test'],
             ],
         ];
 

--- a/tests/Protocol/FetchOffsetTest.php
+++ b/tests/Protocol/FetchOffsetTest.php
@@ -101,6 +101,6 @@ final class FetchOffsetTest extends TestCase
         $expected = '[{"topicName":"test","partitions":[{"partition":0,"errorCode":0,"metadata":"","offset":-1}]}]';
 
         $test = $this->offset->decode(\hex2bin($data));
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/FetchOffsetTest.php
+++ b/tests/Protocol/FetchOffsetTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\FetchOffset;
+use PHPUnit\Framework\TestCase;
 
-final class FetchOffsetTest extends \PHPUnit\Framework\TestCase
+final class FetchOffsetTest extends TestCase
 {
     private $offset;
 

--- a/tests/Protocol/FetchTest.php
+++ b/tests/Protocol/FetchTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Fetch;

--- a/tests/Protocol/FetchTest.php
+++ b/tests/Protocol/FetchTest.php
@@ -132,7 +132,7 @@ final class FetchTest extends TestCase
 
         $test = $this->fetch->decode(\hex2bin($data));
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 
     public function testDecodeCompressedMessage(): void

--- a/tests/Protocol/FetchTest.php
+++ b/tests/Protocol/FetchTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Fetch;
+use PHPUnit\Framework\TestCase;
 
-final class FetchTest extends \PHPUnit\Framework\TestCase
+final class FetchTest extends TestCase
 {
     private $fetch;
 

--- a/tests/Protocol/FetchTest.php
+++ b/tests/Protocol/FetchTest.php
@@ -63,9 +63,7 @@ final class FetchTest extends TestCase
                 [
                     'topic_name' => 'test',
                     'partitions' => [
-                        [
-                            'partition_id' => 0,
-                        ],
+                        ['partition_id' => 0],
                     ],
                 ],
             ],
@@ -100,9 +98,7 @@ final class FetchTest extends TestCase
     {
         $data = [
             'data' => [
-                [
-                    'topic_name' => 'test',
-                ],
+                ['topic_name' => 'test'],
             ],
         ];
 

--- a/tests/Protocol/FetchTest.php
+++ b/tests/Protocol/FetchTest.php
@@ -26,7 +26,7 @@ final class FetchTest extends \PHPUnit\Framework\TestCase
                             'partition_id' => 0,
                             'offset' => 45,
                             'max_bytes' => 128,
-                        ]
+                        ],
                     ],
                 ],
             ],
@@ -59,7 +59,7 @@ final class FetchTest extends \PHPUnit\Framework\TestCase
                     'partitions' => [
                         [
                             'partition_id' => 0,
-                        ]
+                        ],
                     ],
                 ],
             ],

--- a/tests/Protocol/FetchTest.php
+++ b/tests/Protocol/FetchTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class FetchTest extends TestCase
 {
+    /**
+     * @var Fetch
+     */
     private $fetch;
 
     public function setUp(): void

--- a/tests/Protocol/GroupCoordinatorTest.php
+++ b/tests/Protocol/GroupCoordinatorTest.php
@@ -42,6 +42,6 @@ final class GroupCoordinatorTest extends TestCase
 
         $test = $this->group->decode(\hex2bin($data));
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/GroupCoordinatorTest.php
+++ b/tests/Protocol/GroupCoordinatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\GroupCoordinator;

--- a/tests/Protocol/GroupCoordinatorTest.php
+++ b/tests/Protocol/GroupCoordinatorTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\GroupCoordinator;
+use PHPUnit\Framework\TestCase;
 
-final class GroupCoordinatorTest extends \PHPUnit\Framework\TestCase
+final class GroupCoordinatorTest extends TestCase
 {
     private $group;
 

--- a/tests/Protocol/GroupCoordinatorTest.php
+++ b/tests/Protocol/GroupCoordinatorTest.php
@@ -20,9 +20,7 @@ final class GroupCoordinatorTest extends TestCase
 
     public function testEncode(): void
     {
-        $data = [
-            'group_id' => 'test',
-        ];
+        $data = ['group_id' => 'test'];
 
         $test = $this->group->encode($data);
         self::assertSame('00000019000a00000000000a00096b61666b612d706870000474657374', \bin2hex($test));

--- a/tests/Protocol/GroupCoordinatorTest.php
+++ b/tests/Protocol/GroupCoordinatorTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class GroupCoordinatorTest extends TestCase
 {
+    /**
+     * @var GroupCoordinator
+     */
     private $group;
 
     public function setUp(): void

--- a/tests/Protocol/HeartbeatTest.php
+++ b/tests/Protocol/HeartbeatTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Protocol;
 

--- a/tests/Protocol/HeartbeatTest.php
+++ b/tests/Protocol/HeartbeatTest.php
@@ -76,6 +76,6 @@ final class HeartbeatTest extends TestCase
         $test     = $this->heart->decode(\hex2bin('0000'));
         $expected = '{"errorCode":0}';
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/HeartbeatTest.php
+++ b/tests/Protocol/HeartbeatTest.php
@@ -47,9 +47,7 @@ final class HeartbeatTest extends TestCase
      */
     public function testEncodeNoGenerationId(): void
     {
-        $data = [
-            'group_id' => 'test',
-        ];
+        $data = ['group_id' => 'test'];
 
         $this->heart->encode($data);
     }

--- a/tests/Protocol/HeartbeatTest.php
+++ b/tests/Protocol/HeartbeatTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 final class HeartbeatTest extends TestCase
 {
+    /**
+     * @var Heartbeat
+     */
     private $heart;
 
     public function setUp(): void
@@ -68,7 +71,6 @@ final class HeartbeatTest extends TestCase
      * testDecode
      *
      * @access public
-     * @return void
      */
     public function testDecode(): void
     {

--- a/tests/Protocol/HeartbeatTest.php
+++ b/tests/Protocol/HeartbeatTest.php
@@ -3,8 +3,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Heartbeat;
+use PHPUnit\Framework\TestCase;
 
-final class HeartbeatTest extends \PHPUnit\Framework\TestCase
+final class HeartbeatTest extends TestCase
 {
     private $heart;
 

--- a/tests/Protocol/JoinGroupTest.php
+++ b/tests/Protocol/JoinGroupTest.php
@@ -193,6 +193,6 @@ final class JoinGroupTest extends TestCase
 
         $test = $this->group9->decode(\hex2bin($data));
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/JoinGroupTest.php
+++ b/tests/Protocol/JoinGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Protocol;
 

--- a/tests/Protocol/JoinGroupTest.php
+++ b/tests/Protocol/JoinGroupTest.php
@@ -63,9 +63,7 @@ final class JoinGroupTest extends TestCase
      */
     public function testEncodeNoSessionTimeout(): void
     {
-        $data = [
-            'group_id' => 'test',
-        ];
+        $data = ['group_id' => 'test'];
 
         $this->group9->encode($data);
     }
@@ -159,9 +157,7 @@ final class JoinGroupTest extends TestCase
             'rebalance_timeout' => 6000,
             'member_id'         => '',
             'data'              => [
-                [
-                    'protocol_name' => 'group',
-                ],
+                ['protocol_name' => 'group'],
             ],
         ];
 

--- a/tests/Protocol/JoinGroupTest.php
+++ b/tests/Protocol/JoinGroupTest.php
@@ -7,8 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 final class JoinGroupTest extends TestCase
 {
+    /**
+     * @var JoinGroup
+     */
     private $group9;
 
+    /**
+     * @var JoinGroup
+     */
     private $group10;
 
     public function setUp(): void

--- a/tests/Protocol/JoinGroupTest.php
+++ b/tests/Protocol/JoinGroupTest.php
@@ -3,8 +3,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\JoinGroup;
+use PHPUnit\Framework\TestCase;
 
-final class JoinGroupTest extends \PHPUnit\Framework\TestCase
+final class JoinGroupTest extends TestCase
 {
     private $group9;
 

--- a/tests/Protocol/LeaveGroupTest.php
+++ b/tests/Protocol/LeaveGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Protocol;
 

--- a/tests/Protocol/LeaveGroupTest.php
+++ b/tests/Protocol/LeaveGroupTest.php
@@ -46,9 +46,7 @@ final class LeaveGroupTest extends TestCase
      */
     public function testEncodeNoMemberId(): void
     {
-        $data = [
-            'group_id' => 'test',
-        ];
+        $data = ['group_id' => 'test'];
 
         $this->leave->encode($data);
     }

--- a/tests/Protocol/LeaveGroupTest.php
+++ b/tests/Protocol/LeaveGroupTest.php
@@ -56,6 +56,6 @@ final class LeaveGroupTest extends TestCase
         $test     = $this->leave->decode(\hex2bin('0000'));
         $expected = '{"errorCode":0}';
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/LeaveGroupTest.php
+++ b/tests/Protocol/LeaveGroupTest.php
@@ -3,8 +3,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\LeaveGroup;
+use PHPUnit\Framework\TestCase;
 
-final class LeaveGroupTest extends \PHPUnit\Framework\TestCase
+final class LeaveGroupTest extends TestCase
 {
     private $leave;
 

--- a/tests/Protocol/LeaveGroupTest.php
+++ b/tests/Protocol/LeaveGroupTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 final class LeaveGroupTest extends TestCase
 {
+    /**
+     * @var LeaveGroup
+     */
     private $leave;
 
     public function setUp(): void

--- a/tests/Protocol/ListGroupTest.php
+++ b/tests/Protocol/ListGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Protocol;
 

--- a/tests/Protocol/ListGroupTest.php
+++ b/tests/Protocol/ListGroupTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 final class ListGroupTest extends TestCase
 {
+    /**
+     * @var ListGroup
+     */
     private $list;
 
     public function setUp(): void

--- a/tests/Protocol/ListGroupTest.php
+++ b/tests/Protocol/ListGroupTest.php
@@ -3,8 +3,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\ListGroup;
+use PHPUnit\Framework\TestCase;
 
-final class ListGroupTest extends \PHPUnit\Framework\TestCase
+final class ListGroupTest extends TestCase
 {
     private $list;
 

--- a/tests/Protocol/ListGroupTest.php
+++ b/tests/Protocol/ListGroupTest.php
@@ -30,6 +30,6 @@ final class ListGroupTest extends TestCase
         $test     = $this->list->decode(\hex2bin('0000000000010004746573740008636f6e73756d6572'));
         $expected = '{"errorCode":0,"groups":[{"groupId":"test","protocolType":"consumer"}]}';
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/MetadataTest.php
+++ b/tests/Protocol/MetadataTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Metadata;
+use PHPUnit\Framework\TestCase;
 
-final class MetadataTest extends \PHPUnit\Framework\TestCase
+final class MetadataTest extends TestCase
 {
     private $meta;
 

--- a/tests/Protocol/MetadataTest.php
+++ b/tests/Protocol/MetadataTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class MetadataTest extends TestCase
 {
+    /**
+     * @var Metadata
+     */
     private $meta;
 
     public function setUp(): void

--- a/tests/Protocol/MetadataTest.php
+++ b/tests/Protocol/MetadataTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Metadata;

--- a/tests/Protocol/MetadataTest.php
+++ b/tests/Protocol/MetadataTest.php
@@ -48,6 +48,6 @@ final class MetadataTest extends TestCase
 
         $test = $this->meta->decode(\hex2bin($data));
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/OffsetTest.php
+++ b/tests/Protocol/OffsetTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Protocol;
 

--- a/tests/Protocol/OffsetTest.php
+++ b/tests/Protocol/OffsetTest.php
@@ -117,6 +117,6 @@ final class OffsetTest extends TestCase
 
         $test = $this->offset->decode(\hex2bin($data));
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($test));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($test));
     }
 }

--- a/tests/Protocol/OffsetTest.php
+++ b/tests/Protocol/OffsetTest.php
@@ -7,8 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 final class OffsetTest extends TestCase
 {
+    /**
+     * @var Offset
+     */
     private $offset;
 
+    /**
+     * @var Offset
+     */
     private $offset10;
 
     public function setUp(): void
@@ -104,7 +110,6 @@ final class OffsetTest extends TestCase
      * testDecode
      *
      * @access public
-     * @return void
      */
     public function testDecode(): void
     {

--- a/tests/Protocol/OffsetTest.php
+++ b/tests/Protocol/OffsetTest.php
@@ -3,8 +3,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Offset;
+use PHPUnit\Framework\TestCase;
 
-final class OffsetTest extends \PHPUnit\Framework\TestCase
+final class OffsetTest extends TestCase
 {
     private $offset;
 

--- a/tests/Protocol/OffsetTest.php
+++ b/tests/Protocol/OffsetTest.php
@@ -78,9 +78,7 @@ final class OffsetTest extends TestCase
     {
         $data = [
             'data' => [
-                [
-                    'topic_name' => 'test',
-                ],
+                ['topic_name' => 'test'],
             ],
         ];
 

--- a/tests/Protocol/ProduceTest.php
+++ b/tests/Protocol/ProduceTest.php
@@ -158,9 +158,7 @@ final class ProduceTest extends TestCase
     {
         $data = [
             'data' => [
-                [
-                    'topic_name' => 'test',
-                ],
+                ['topic_name' => 'test'],
             ],
         ];
 
@@ -200,9 +198,7 @@ final class ProduceTest extends TestCase
                 [
                     'topic_name' => 'test',
                     'partitions' => [
-                        [
-                            'partition_id' => 0,
-                        ],
+                        ['partition_id' => 0],
                     ],
                 ],
             ],

--- a/tests/Protocol/ProduceTest.php
+++ b/tests/Protocol/ProduceTest.php
@@ -212,7 +212,7 @@ final class ProduceTest extends TestCase
         $data     = '0000000100047465737400000001000000000000000000000000002a00000000';
         $expected = '{"throttleTime":0,"data":[{"topicName":"test","partitions":[{"partition":0,"errorCode":0,"offset":14,"timestamp":0}]}]}';
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($this->produce->decode(\hex2bin($data))));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($this->produce->decode(\hex2bin($data))));
     }
 
     public function testDecodeKafka10(): void
@@ -220,6 +220,6 @@ final class ProduceTest extends TestCase
         $data     = '0000000100047465737400000001000000000000000000000000006effffffffffffffff00000000';
         $expected = '{"throttleTime":0,"data":[{"topicName":"test","partitions":[{"partition":0,"errorCode":0,"offset":22,"timestamp":-1}]}]}';
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($this->produce10->decode(\hex2bin($data))));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($this->produce10->decode(\hex2bin($data))));
     }
 }

--- a/tests/Protocol/ProduceTest.php
+++ b/tests/Protocol/ProduceTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Produce;

--- a/tests/Protocol/ProduceTest.php
+++ b/tests/Protocol/ProduceTest.php
@@ -7,8 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 final class ProduceTest extends TestCase
 {
+    /**
+     * @var Produce
+     */
     private $produce;
 
+    /**
+     * @var Produce
+     */
     private $produce10;
 
     public function setUp(): void

--- a/tests/Protocol/ProduceTest.php
+++ b/tests/Protocol/ProduceTest.php
@@ -57,7 +57,7 @@ final class ProduceTest extends \PHPUnit\Framework\TestCase
                         [
                             'partition_id' => 0,
                             'messages' => [
-                                ['key' => 'testkey', 'value' => 'test...']
+                                ['key' => 'testkey', 'value' => 'test...'],
                             ],
                         ],
                     ],
@@ -81,7 +81,7 @@ final class ProduceTest extends \PHPUnit\Framework\TestCase
                     'partitions' => [
                         [
                             'partition_id' => 0,
-                            'messages' => 'test...'
+                            'messages' => 'test...',
                         ],
                     ],
                 ],

--- a/tests/Protocol/ProduceTest.php
+++ b/tests/Protocol/ProduceTest.php
@@ -3,8 +3,9 @@ namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\Produce;
 use Lcobucci\Clock\FrozenClock;
+use PHPUnit\Framework\TestCase;
 
-final class ProduceTest extends \PHPUnit\Framework\TestCase
+final class ProduceTest extends TestCase
 {
     private $produce;
 

--- a/tests/Protocol/SaslHandShakeTest.php
+++ b/tests/Protocol/SaslHandShakeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace KafkaTest\Protocol;
 

--- a/tests/Protocol/SaslHandShakeTest.php
+++ b/tests/Protocol/SaslHandShakeTest.php
@@ -3,8 +3,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\SaslHandShake;
+use PHPUnit\Framework\TestCase;
 
-final class SaslHandShakeTest extends \PHPUnit\Framework\TestCase
+final class SaslHandShakeTest extends TestCase
 {
     private $sasl;
 

--- a/tests/Protocol/SaslHandShakeTest.php
+++ b/tests/Protocol/SaslHandShakeTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 final class SaslHandShakeTest extends TestCase
 {
+    /**
+     * @var SaslHandShake
+     */
     private $sasl;
 
     public function setUp(): void
@@ -43,7 +46,6 @@ final class SaslHandShakeTest extends TestCase
      * testDecode
      *
      * @access public
-     * @return void
      */
     public function testDecode(): void
     {

--- a/tests/Protocol/SaslHandShakeTest.php
+++ b/tests/Protocol/SaslHandShakeTest.php
@@ -53,6 +53,6 @@ final class SaslHandShakeTest extends TestCase
         $data     = '0022000000010006475353415049';
         $expected = '{"mechanisms":["GSSAPI"],"errorCode":34}';
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($this->sasl->decode(\hex2bin($data))));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($this->sasl->decode(\hex2bin($data))));
     }
 }

--- a/tests/Protocol/SyncGroupTest.php
+++ b/tests/Protocol/SyncGroupTest.php
@@ -2,8 +2,9 @@
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\SyncGroup;
+use PHPUnit\Framework\TestCase;
 
-final class SyncGroupTest extends \PHPUnit\Framework\TestCase
+final class SyncGroupTest extends TestCase
 {
     private $sync;
 

--- a/tests/Protocol/SyncGroupTest.php
+++ b/tests/Protocol/SyncGroupTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace KafkaTest\Protocol;
 
 use Kafka\Protocol\SyncGroup;

--- a/tests/Protocol/SyncGroupTest.php
+++ b/tests/Protocol/SyncGroupTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 final class SyncGroupTest extends TestCase
 {
+    /**
+     * @var SyncGroup
+     */
     private $sync;
 
     public function setUp(): void

--- a/tests/Protocol/SyncGroupTest.php
+++ b/tests/Protocol/SyncGroupTest.php
@@ -45,9 +45,7 @@ final class SyncGroupTest extends TestCase
      */
     public function testEncodeNoGenerationId(): void
     {
-        $data = [
-            'group_id' => 'test',
-        ];
+        $data = ['group_id' => 'test'];
 
         $this->sync->encode($data);
     }
@@ -92,9 +90,7 @@ final class SyncGroupTest extends TestCase
             'generation_id' => '1',
             'member_id' => 'kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c',
             'data' => [
-                [
-
-                ],
+                [],
             ],
         ];
 
@@ -112,9 +108,7 @@ final class SyncGroupTest extends TestCase
             'generation_id' => '1',
             'member_id' => 'kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c',
             'data' => [
-                [
-                    'version' => 0,
-                ],
+                ['version' => 0],
             ],
         ];
 
@@ -181,9 +175,7 @@ final class SyncGroupTest extends TestCase
                     'version' => 0 ,
                     'member_id' => 'kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c',
                     'assignments' => [
-                        [
-                            'topic_name' => 'test',
-                        ],
+                        ['topic_name' => 'test'],
                     ],
                 ],
             ],

--- a/tests/Protocol/SyncGroupTest.php
+++ b/tests/Protocol/SyncGroupTest.php
@@ -20,7 +20,7 @@ final class SyncGroupTest extends TestCase
 
     public function testEncode(): void
     {
-        $data = json_decode(
+        $data = \json_decode(
             '{"group_id":"test","generation_id":1,"member_id":"kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c","data":[{"version":0,"member_id":"kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c","assignments":[{"topic_name":"test","partitions":[0]}]}]}',
             true
         );
@@ -189,7 +189,7 @@ final class SyncGroupTest extends TestCase
         $data     = '000000000018000000000001000474657374000000010000000000000000';
         $expected = '{"errorCode":0,"partitionAssignments":[{"topicName":"test","partitions":[0]}],"version":0,"userData":""}';
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($this->sync->decode(\hex2bin($data))));
-        self::assertJsonStringEqualsJsonString('{"errorCode":0}', json_encode($this->sync->decode(\hex2bin('000000000000'))));
+        self::assertJsonStringEqualsJsonString($expected, \json_encode($this->sync->decode(\hex2bin($data))));
+        self::assertJsonStringEqualsJsonString('{"errorCode":0}', \json_encode($this->sync->decode(\hex2bin('000000000000'))));
     }
 }

--- a/tests/Protocol/SyncGroupTest.php
+++ b/tests/Protocol/SyncGroupTest.php
@@ -69,7 +69,7 @@ final class SyncGroupTest extends \PHPUnit\Framework\TestCase
         $data = [
             'group_id' => 'test',
             'generation_id' => '1',
-            'member_id' => 'kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c'
+            'member_id' => 'kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c',
         ];
 
         $this->sync->encode($data);
@@ -107,7 +107,7 @@ final class SyncGroupTest extends \PHPUnit\Framework\TestCase
             'member_id' => 'kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c',
             'data' => [
                 [
-                    'version' => 0
+                    'version' => 0,
                 ],
             ],
         ];
@@ -152,7 +152,7 @@ final class SyncGroupTest extends \PHPUnit\Framework\TestCase
                     'member_id' => 'kafka-php-bd5d5bb2-2a1f-43d4-b831-b1510d81ac5c',
                     'assignments' => [
                         [],
-                    ]
+                    ],
                 ],
             ],
         ];
@@ -178,7 +178,7 @@ final class SyncGroupTest extends \PHPUnit\Framework\TestCase
                         [
                             'topic_name' => 'test',
                         ],
-                    ]
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
This PR adds several rules to PHPCS to make it more strict regarding our code, helping us to standardise almost everything. Some of the rules have high impact on the code (like forcing type declaration and forcing strict scalar mode in every file) but they will also help us to avoid nasty bugs due to type juggling.

I've tried as much as possible to organise the commits in a logical way, and it's important to mention that each commit is a suggestion (we can drop them if you prefer to not be that strict).

Also important to mention that this PR depends on #167