### PR TITLE
bugfix:Missing parentheses in function checkRun at Comsumer/State.php#322 to v0.2.0-dev

### DIFF
--- a/src/Consumer/State.php
+++ b/src/Consumer/State.php
@@ -232,7 +232,7 @@ class State
         $status = $this->callStatus[$key]['status'];
         switch ($key) {
             case self::REQUEST_METADATA:
-                if ($status & self::STATUS_PROCESS == self::STATUS_PROCESS) {
+                if (($status & self::STATUS_PROCESS) == self::STATUS_PROCESS) {
                     return false;
                 }
                 if (($status & self::STATUS_LOOP) == self::STATUS_LOOP) {


### PR DESCRIPTION
Missing parentheses in function checkRun at Comsumer/State.php#322? Because "&" has a lower precedence than "==".