### PR TITLE
bugfix: issue141, missing the first message

### DIFF
--- a/src/Kafka/Consumer/Process.php
+++ b/src/Kafka/Consumer/Process.php
@@ -639,8 +639,8 @@ class Process
                     continue;
                 }
 
-                $offset = $assign->getConsumerOffset($topic['topicName'], $part['partition']);
-                if ($offset === false) {
+                $consumerOffset = $assign->getConsumerOffset($topic['topicName'], $part['partition']);
+                if ($consumerOffset === false) {
                     return; // current is rejoin....
                 }
                 foreach ($part['messages'] as $message) {
@@ -648,14 +648,17 @@ class Process
                     //if ($this->consumer != null) {
                     //    call_user_func($this->consumer, $topic['topicName'], $part['partition'], $message);
                     //}
-                    $offset = $message['offset'];
+                    $commitOffset = $message['offset'];
                 }
 
-                $consumerOffset = ($part['highwaterMarkOffset'] > $offset) ? ($offset + 1) : $offset;
+                $commitOffset = isset($commitOffset) ? $commitOffset : $consumerOffset - 1;
+                $consumerOffset = $commitOffset + 1;
+
                 $assign->setConsumerOffset($topic['topicName'], $part['partition'], $consumerOffset);
-                $assign->setCommitOffset($topic['topicName'], $part['partition'], $offset);
+                $assign->setCommitOffset($topic['topicName'], $part['partition'], $commitOffset);
             }
         }
+        //获取消息中没有消息时，不能提交才行
         $this->state->succRun(\Kafka\Consumer\State::REQUEST_FETCH, $fd);
     }
 


### PR DESCRIPTION
Cause for this issue:when no new messages is available, the fetch request is also successful, and the message array in response is empty, but consumer also commits the offset. At this situation the consumer offset is equal to commit offset, so if you don't stop the consumer, the commit offset will be corrected by next successful fetch request, if you restart the consumer, the offset request will return the offset you committed last time.