### PR TITLE
bugfix, issue141,179: lost message when consumer restart

### DIFF
--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -644,21 +644,22 @@ class Process
                     continue;
                 }
 
-                $offset = $assign->getConsumerOffset($topic['topicName'], $part['partition']);
-
-                if ($offset === null) {
+                $consumerOffset = $assign->getConsumerOffset($topic['topicName'], $part['partition']);
+                if ($consumerOffset === null) {
                     return; // current is rejoin....
                 }
 
+                $commitOffset = $consumerOffset - 1;
                 foreach ($part['messages'] as $message) {
                     $this->messages[$topic['topicName']][$part['partition']][] = $message;
 
-                    $offset = $message['offset'];
+                    $commitOffset = $message['offset'];
                 }
 
-                $consumerOffset = ($part['highwaterMarkOffset'] > $offset) ? ($offset + 1) : $offset;
+                $consumerOffset = $commitOffset + 1;
+
                 $assign->setConsumerOffset($topic['topicName'], $part['partition'], $consumerOffset);
-                $assign->setCommitOffset($topic['topicName'], $part['partition'], $offset);
+                $assign->setCommitOffset($topic['topicName'], $part['partition'], $commitOffset);
             }
         }
 


### PR DESCRIPTION
The cause of this issue:
When no new messages is available, the fetch request is also successful, and the message array in response is empty, but consumer also commits the offset. At this situation the consumer offset is equal to commit offset, so if you don't stop the consumer, the commit offset will be corrected by next successful fetch request, if you restart the consumer, the offset request will return the offset you committed last time.

Base on kafka protocol, highwaterMarkOffset represents "The offset at the end of the log for this partition. This can be used by the client to determine how many messages behind the end of the log they are.", so it is useless.