### PR TITLE
Choose partition by key for several brokers

### DIFF
--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -134,12 +134,15 @@ class SyncProcess
 
             $topicMeta = $topicInfos[$value['topic']];
             $partNums  = array_keys($topicMeta);
-            shuffle($partNums);
-            $partId = 0;
-            if (! isset($value['partId']) || ! isset($topicMeta[$value['partId']])) {
-                $partId = $partNums[0];
+            if (isset($value['key'])&&trim($value['key'])){
+                $partId = crc32($value['key']) % count($partNums);
             } else {
-                $partId = $value['partId'];
+                shuffle($partNums);
+                if (! isset($value['partId']) || ! isset($topicMeta[$value['partId']])) {
+                    $partId = $partNums[0];
+                } else {
+                    $partId = $value['partId'];
+                }
             }
 
             $brokerId  = $topicMeta[$partId];


### PR DESCRIPTION
Hi,
I have three brokers and when I, for example, write 5 messages in a cycle, they come in random order.
Before choosing a broker we need to select partition by key, so that the messages were written consistently in correct order.