### PR TITLE
Add sync/async sockets differentiation for broker

### DIFF
--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -67,7 +67,7 @@ class SyncProcess
         $sendData = $this->convertRecordSet($recordSet);
         $result   = [];
         foreach ($sendData as $brokerId => $topicList) {
-            $connect = $broker->getDataConnect((string) $brokerId, true);
+            $connect = $broker->getDataConnect((string) $brokerId, Broker::SOCKET_MODE_SYNC);
 
             if ($connect === null) {
                 return [];
@@ -118,7 +118,7 @@ class SyncProcess
         $broker = $this->getBroker();
 
         foreach ($brokerHost as $host) {
-            $socket = $broker->getMetaConnect($host, true);
+            $socket = $broker->getMetaConnect($host, Broker::SOCKET_MODE_SYNC);
 
             if ($socket === null) {
                 continue;

--- a/src/SocketFactory.php
+++ b/src/SocketFactory.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Kafka;
+
+class SocketFactory
+{
+    public function createSocket(
+        string $host,
+        int $port,
+        ?Config $config = null,
+        ?SaslMechanism $saslProvider = null
+    ): Socket {
+        return new Socket($host, $port, $config, $saslProvider);
+    }
+
+    public function createSocketSync(
+        string $host,
+        int $port,
+        ?Config $config = null,
+        ?SaslMechanism $saslProvider = null
+    ): SocketSync {
+        return new SocketSync($host, $port, $config, $saslProvider);
+    }
+}


### PR DESCRIPTION
When attempt to use sync producer inside async consumer with the same broker, was able to access only async socket with `Broker::getConnect()`. Tried to solve this issue with this PR. There already was an [issue](https://github.com/weiboad/kafka-php/issues/205) regarding this.

Thank you in advance.