### PR TITLE
Auto create topics producer

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -24,6 +24,7 @@ use function version_compare;
  * @method int getMetadataRequestTimeoutMs()
  * @method int getMetadataRefreshIntervalMs()
  * @method int getMetadataMaxAgeMs()
+ * @method bool getAutoCreateTopicsEnable()
  * @method string getSecurityProtocol()
  * @method bool getSslEnable()
  * @method void setSslEnable(bool $sslEnable)
@@ -84,6 +85,7 @@ abstract class Config
         'metadataRequestTimeoutMs'  => 60000,
         'metadataRefreshIntervalMs' => 300000,
         'metadataMaxAgeMs'          => -1,
+        'autoCreateTopicsEnable'    => true,
         'securityProtocol'          => self::SECURITY_PROTOCOL_PLAINTEXT,
         'sslEnable'                 => false, // this config item will override, don't config it.
         'sslLocalCert'              => '',
@@ -239,6 +241,11 @@ abstract class Config
             throw new Exception\Config('Set metadata max age value is invalid, must set it 1 .. 86400000');
         }
         static::$options['metadataMaxAgeMs'] = $metadataMaxAgeMs;
+    }
+
+    public function setAutoCreateTopicsEnable(bool $flag = true): void
+    {
+        static::$options['autoCreateTopicsEnable'] = $flag;
     }
 
     /**

--- a/src/Producer/RecordValidator.php
+++ b/src/Producer/RecordValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Kafka\Producer;
 
 use Kafka\Exception;
+use Kafka\ProducerConfig;
 use function is_string;
 use function trim;
 
@@ -30,7 +31,10 @@ final class RecordValidator
             throw Exception\InvalidRecordInSet::missingTopic();
         }
 
-        if (! isset($topicList[$record['topic']])) {
+        /** @var ProducerConfig $config */
+        $config = ProducerConfig::getInstance();
+
+        if (! isset($topicList[$record['topic']]) && ! $config->getAutoCreateTopicsEnable()) {
             throw Exception\InvalidRecordInSet::nonExististingTopic($record['topic']);
         }
 

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -67,7 +67,7 @@ class SyncProcess
         $sendData = $this->convertRecordSet($recordSet);
         $result   = [];
         foreach ($sendData as $brokerId => $topicList) {
-            $connect = $broker->getDataConnect((string) $brokerId, true);
+            $connect = $broker->getDataConnect((string) $brokerId, Broker::SOCKET_MODE_SYNC);
 
             if ($connect === null) {
                 return [];
@@ -118,7 +118,7 @@ class SyncProcess
         $broker = $this->getBroker();
 
         foreach ($brokerHost as $host) {
-            $socket = $broker->getMetaConnect($host, true);
+            $socket = $broker->getMetaConnect($host, Broker::SOCKET_MODE_SYNC);
 
             if ($socket === null) {
                 continue;

--- a/src/SocketFactory.php
+++ b/src/SocketFactory.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Kafka;
+
+class SocketFactory
+{
+    public function createSocket(
+        string $host,
+        int $port,
+        ?Config $config = null,
+        ?SaslMechanism $saslProvider = null
+    ): Socket {
+        return new Socket($host, $port, $config, $saslProvider);
+    }
+
+    public function createSocketSync(
+        string $host,
+        int $port,
+        ?Config $config = null,
+        ?SaslMechanism $saslProvider = null
+    ): SocketSync {
+        return new SocketSync($host, $port, $config, $saslProvider);
+    }
+}

--- a/tests/Base/Producer/RecordValidatorTest.php
+++ b/tests/Base/Producer/RecordValidatorTest.php
@@ -5,6 +5,7 @@ namespace KafkaTest\Base\Producer;
 
 use Kafka\Exception\InvalidRecordInSet;
 use Kafka\Producer\RecordValidator;
+use Kafka\ProducerConfig;
 use PHPUnit\Framework\TestCase;
 
 final class RecordValidatorTest extends TestCase
@@ -15,6 +16,10 @@ final class RecordValidatorTest extends TestCase
     public function setUp(): void
     {
         $this->recordValidator = new RecordValidator();
+
+        /** @var ProducerConfig $config */
+        $config = ProducerConfig::getInstance();
+        $config->setAutoCreateTopicsEnable(false);
 
         parent::setUp();
     }
@@ -60,5 +65,18 @@ final class RecordValidatorTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessDocComment
+     */
+    public function testValidateNonExistingTopicWhenAutoCreateTopicsEnabled(): void
+    {
+        /** @var ProducerConfig $config */
+        $config = ProducerConfig::getInstance();
+        $config->setAutoCreateTopicsEnable(true);
+
+        $this->recordValidator->validate(['topic' => 'test', 'value' => 'a value'], []);
     }
 }

--- a/tests/Functional/Ticket/GH181Test.php
+++ b/tests/Functional/Ticket/GH181Test.php
@@ -22,9 +22,11 @@ final class GH181Test extends TestCase
             );
         }
 
+        /** @var ProducerConfig $config */
         $config = ProducerConfig::getInstance();
         $config->setMetadataBrokerList($brokers);
         $config->setBrokerVersion($version);
+        $config->setAutoCreateTopicsEnable(false);
 
         parent::setUp();
     }


### PR DESCRIPTION
Thank you for the great library.

As it was mentioned in [this issue](https://github.com/weiboad/kafka-php/issues/206) it would be nice to be able to set topic creation option to be in line with `auto.create.topics.enable` broker option. According to [docs](https://kafka.apache.org/documentation/) the default option is `true`, so I added this to `Kafka\Config`.

Thank you in advance. 