### PR TITLE
Choose partition by key for several brokers (to master)

### DIFF
--- a/src/Broker.php
+++ b/src/Broker.php
@@ -281,4 +281,21 @@ class Broker
 
         throw new Exception(sprintf('"%s" is an invalid SASL mechanism', $mechanism));
     }
+
+    /**
+     * @param array $record
+     * @return int
+     */
+    public function getPartitionId($record)
+    {
+        $topicInfos = $this->getTopics();
+        $topicMeta  = $topicInfos[$record['topic']];
+        $partNums   = array_keys($topicMeta);
+        if (isset($record['key']) && trim($record['key'])) {
+            $partId = $partNums[crc32($record['key']) % count($partNums)];
+        } else {
+            $partId = isset($record['partId'], $topicMeta[$record['partId']]) ? $record['partId'] : $partNums[0];
+        }
+        return $partId;
+    }
 }

--- a/src/Producer/Process.php
+++ b/src/Producer/Process.php
@@ -320,10 +320,7 @@ class Process
             $this->recordValidator->validate($record, $topics);
 
             $topicMeta = $topics[$record['topic']];
-            $partNums  = array_keys($topicMeta);
-            shuffle($partNums);
-
-            $partId = ! isset($record['partId'], $topicMeta[$record['partId']]) ? $partNums[0] : $record['partId'];
+            $partId    = $broker->getPartitionId($record);
 
             $brokerId  = $topicMeta[$partId];
             $topicData = [];

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -161,10 +161,7 @@ class SyncProcess
             $this->recordValidator->validate($record, $topics);
 
             $topicMeta = $topics[$record['topic']];
-            $partNums  = array_keys($topicMeta);
-            shuffle($partNums);
-
-            $partId = isset($record['partId'], $topicMeta[$record['partId']]) ? $record['partId'] : $partNums[0];
+            $partId    = $broker->getPartitionId($record);
 
             $brokerId  = $topicMeta[$partId];
             $topicData = [];

--- a/tests/Base/BrokerTest.php
+++ b/tests/Base/BrokerTest.php
@@ -150,4 +150,60 @@ class BrokerTest extends TestCase
     {
         return Broker::getInstance();
     }
+
+    /**
+     * testGetPartitionId
+     *
+     * @access public
+     * @return void
+     */
+    public function testGetPartitionId()
+    {
+        $broker = \Kafka\Broker::getInstance();
+        $data   = [
+            'brokers' => [
+                [
+                    'host' => '127.0.0.1',
+                    'port' => '9092',
+                    'nodeId' => '0',
+                ],
+                [
+                    'host' => '127.0.0.1',
+                    'port' => '9192',
+                    'nodeId' => '1',
+                ],
+                [
+                    'host' => '127.0.0.1',
+                    'port' => '9292',
+                    'nodeId' => '2',
+                ],
+            ],
+            'topics' => [
+                [
+                    'topicName' => 'test',
+                    'errorCode' => 0,
+                    'partitions' => [
+                        [
+                            'partitionId' => 0,
+                            'errorCode' => 0,
+                            'leader' => 0,
+                        ],
+                        [
+                            'partitionId' => 1,
+                            'errorCode' => 0,
+                            'leader' => 2,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $broker->setData($data['topics'], $data['brokers']);
+        $data   = [
+            'partId' => '1',
+            'topic' => 'test',
+            'value' => 'test message'
+        ];
+        $partId = $broker->getPartitionId($data);
+        $this->assertEquals('1', $partId);
+    }
 }


### PR DESCRIPTION
Hi,
I changed destination branch to master and correct tests. I closed old pull request.
https://github.com/weiboad/kafka-php/pull/208

Why change:
I have three brokers and when I, for example, write 5 messages in a cycle, they come in random order.
Before choosing a broker we need to select partition by key, so that the messages were written consistently in correct order.