### PR TITLE
Add Verify Peer Name Config

### DIFF
--- a/src/CommonSocket.php
+++ b/src/CommonSocket.php
@@ -142,12 +142,13 @@ abstract class CommonSocket
             $context = stream_context_create(
                 [
                     'ssl' => [
-                        'local_cert'  => $this->config->getSslLocalCert(),
-                        'local_pk'    => $this->config->getSslLocalPk(),
-                        'verify_peer' => $this->config->getSslVerifyPeer(),
-                        'passphrase'  => $this->config->getSslPassphrase(),
-                        'cafile'      => $this->config->getSslCafile(),
-                        'peer_name'   => $this->config->getSslPeerName(),
+                        'local_cert'       => $this->config->getSslLocalCert(),
+                        'local_pk'         => $this->config->getSslLocalPk(),
+                        'verify_peer'      => $this->config->getSslVerifyPeer(),
+                        'verify_peer_name' => $this->config->getSslVerifyPeerName(),
+                        'passphrase'       => $this->config->getSslPassphrase(),
+                        'cafile'           => $this->config->getSslCafile(),
+                        'peer_name'        => $this->config->getSslPeerName(),
                     ],
                 ]
             );

--- a/src/Config.php
+++ b/src/Config.php
@@ -31,6 +31,8 @@ use function version_compare;
  * @method string getSslLocalPk()
  * @method bool getSslVerifyPeer()
  * @method void setSslVerifyPeer(bool $sslVerifyPeer)
+ * @method bool getSslVerifyPeerName()
+ * @method void setSslVerifyPeerName(bool $sslVerifyPeerName)
  * @method string getSslPassphrase()
  * @method void setSslPassphrase(string $sslPassphrase)
  * @method string getSslCafile()
@@ -89,6 +91,7 @@ abstract class Config
         'sslLocalCert'              => '',
         'sslLocalPk'                => '',
         'sslVerifyPeer'             => false,
+        'sslVerifyPeerName'         => false,
         'sslPassphrase'             => '',
         'sslCafile'                 => '',
         'sslPeerName'               => '',

--- a/tests/Base/SocketTest.php
+++ b/tests/Base/SocketTest.php
@@ -94,24 +94,26 @@ class SocketTest extends TestCase
 
     public function testCreateStreamSsl(): void
     {
-        $host       = '127.0.0.1';
-        $port       = 9192;
-        $localCert  = $this->root->url() . '/localCert';
-        $localKey   = $this->root->url() . '/localKey';
-        $verifyPeer = false;
-        $passphrase = '123456';
-        $cafile     = $this->root->url() . '/cafile';
-        $peerName   = 'kafka';
+        $host           = '127.0.0.1';
+        $port           = 9192;
+        $localCert      = $this->root->url() . '/localCert';
+        $localKey       = $this->root->url() . '/localKey';
+        $verifyPeer     = false;
+        $verifyPeerName = false;
+        $passphrase     = '123456';
+        $cafile         = $this->root->url() . '/cafile';
+        $peerName       = 'kafka';
 
         $context = stream_context_create(
             [
                 'ssl' => [
-                    'local_cert'  => $localCert,
-                    'local_pk'    => $localKey,
-                    'verify_peer' => $verifyPeer,
-                    'passphrase'  => $passphrase,
-                    'cafile'      => $cafile,
-                    'peer_name'   => $peerName,
+                    'local_cert'       => $localCert,
+                    'local_pk'         => $localKey,
+                    'verify_peer'      => $verifyPeer,
+                    'verify_peer_name' => $verifyPeerName,
+                    'passphrase'       => $passphrase,
+                    'cafile'           => $cafile,
+                    'peer_name'        => $peerName,
                 ],
             ]
         );
@@ -129,6 +131,7 @@ class SocketTest extends TestCase
         $config->setSslCafile($cafile);
         $config->setSslPassphrase($passphrase);
         $config->setSslVerifyPeer($verifyPeer);
+        $config->setSslVerifyPeerName($verifyPeerName);
         $config->setSslPeerName($peerName);
 
         $sasl = $this->createMock(SaslMechanism::class);


### PR DESCRIPTION
Only `verify_peer => false` didn't worked for me, but setting `verify_peer_name => false` did. Guess is an important [SSL context option](http://php.net/manual/en/context.ssl.php). Closes #246.