### PR TITLE
Update Process.php

### DIFF
--- a/src/Consumer/Process.php
+++ b/src/Consumer/Process.php
@@ -651,7 +651,7 @@ class Process
                 foreach ($part['messages'] as $message) {
                     $this->messages[$topic['topicName']][$part['partition']][] = $message;
 
-                    $offset = $offset > $message['offset'] ? $offset : $message['offset'];
+                    $offset = $offset > $message['offset'] ? $offset + 1 : $message['offset'];
                 }
 
                 $consumerOffset = ($part['highwaterMarkOffset'] > $offset) ? ($offset + 1) : $offset;


### PR DESCRIPTION
I'm using kafka 1.1.1. somehow, after each consume, its offest remain to be `0`, then I found only one offset in messages are `0` or `1`, to tell the server I've done my job,I force to commit the biggset offset in the message sets.

我使用的 kafka 1.1.1，很诡异的是提交的 offset 是0，打了日志发现每次拿到消息集合里的消息 offset不是0就是1，这里强制让提交的 offset 按条数增长，试试看能不能解决问题。