### PR TITLE
修改使用的 psr/log 版本號避免衝突

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,34 @@
 {
-    "name": "nmred/kafka-php",
-    "description": "Kafka client for php",
-    "type": "library",
-    "keywords": [
-        "Client",
-        "Kafka"
-    ],
-    "homepage": "http://www.swanlinux.net",
-    "license": "BSD-3-Clause",
-    "config": {
-        "platform": {
-            "php": "7.1.12"
-        },
-        "preferred-install": "dist",
-        "sort-packages": true
-    },
-    "require": {
-        "php": "^7.1",
-        "amphp/amp": "^2.0.3",
-        "lcobucci/clock": "^1.0",
-        "psr/log": "^1.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Kafka\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "KafkaTest\\": "tests/",
-            "KafkaExample\\": "example/"
-        }
-    },
-    "suggest": {
-        "ext-krb5": "To be able to ues the GSSAPI SASL mechanism"
-    },
-    "require-dev": {
-        "doctrine/coding-standard": "^2.1",
-        "infection/infection": "^0.7",
-        "kmelia/monolog-stdout-handler": "^1.2",
-        "mikey179/vfsStream": "^1.6.5",
-        "monolog/monolog": "^1.23",
-        "phpstan/phpstan": "^0.9",
-        "phpstan/phpstan-phpunit": "^0.9",
-        "phpstan/phpstan-strict-rules": "^0.9",
-        "phpunit/phpcov": "^4.0",
-        "phpunit/phpunit": "^6.5",
-        "satooshi/php-coveralls": "2.0.0",
-        "slevomat/coding-standard": "^4.1",
-        "squizlabs/php_codesniffer": "^3.2"
+  "name": "nmred/kafka-php",
+  "description": "Kafka client for php",
+  "type": "library",
+  "keywords": [
+    "Client",
+    "Kafka"
+  ],
+  "homepage": "http://www.swanlinux.net",
+  "license": "BSD-3-Clause",
+  "require": {
+    "php": ">=5.5",
+    "psr/log": "^1.0",
+    "amphp/amp": "v1.2.2"
+  },
+  "autoload": {
+    "psr-0": {
+      "Kafka\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-0": {
+      "KafkaTest\\": "tests/",
+      "KafkaExample\\": "example/"
+    }
+  },
+  "require-dev": {
+    "satooshi/php-coveralls": "dev-master",
+    "phpunit/phpcov": "*",
+    "monolog/monolog": "1.22.1",
+    "kmelia/monolog-stdout-handler": "1.2.1",
+    "phpunit/PHPUnit": "~4.0"
+  }
 }


### PR DESCRIPTION
您好：
我目前有在使用 v0.2.0.8 的版本，最近公司要升級 laravel 5.8，預設的 psr/log 版本跟目前使用的版本有衝突，希望可以將這個分支merge到 v0.2.0.8 裡面，感謝～