### PR TITLE
Fixing problems with SSL, timeout and auto creation of topics

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -84,6 +84,7 @@ abstract class Config
         'metadataRequestTimeoutMs'  => 60000,
         'metadataRefreshIntervalMs' => 300000,
         'metadataMaxAgeMs'          => -1,
+        'autoCreateTopicsEnable'    => true,
         'securityProtocol'          => self::SECURITY_PROTOCOL_PLAINTEXT,
         'sslEnable'                 => false, // this config item will override, don't config it.
         'sslLocalCert'              => '',
@@ -239,6 +240,14 @@ abstract class Config
             throw new Exception\Config('Set metadata max age value is invalid, must set it 1 .. 86400000');
         }
         static::$options['metadataMaxAgeMs'] = $metadataMaxAgeMs;
+    }
+
+    /**
+     * @throws Exception\Config
+     */
+    public function setAutoCreateTopicsEnable(bool $flag = true): void
+    {
+        static::$options['autoCreateTopicsEnable'] = $flag;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -90,6 +90,7 @@ abstract class Config
         'sslLocalCert'              => '',
         'sslLocalPk'                => '',
         'sslVerifyPeer'             => false,
+        'sslVerifyPeerName'         => true,
         'sslPassphrase'             => '',
         'sslCafile'                 => '',
         'sslPeerName'               => '',
@@ -98,6 +99,10 @@ abstract class Config
         'saslPassword'              => '',
         'saslKeytab'                => '',
         'saslPrincipal'             => '',
+        'sendTimeoutSec'            => 0,
+        'sendTimeoutUsec'           => 100000,
+        'recvTimeoutSec'            => 0,
+        'recvTimeoutUsec'           => 750000,
     ];
 
     /**
@@ -320,5 +325,45 @@ abstract class Config
         }
 
         static::$options['saslMechanism'] = $mechanism;
+    }
+
+    /**
+     * @throws Exception\Config
+     */
+    public function setSendTimeoutSec(int $timeout): void
+    {
+        static::$options['sendTimeoutSec'] = $timeout;
+    }
+
+    /**
+     * @throws Exception\Config
+     */
+    public function setSendTimeoutUsec(int $timeout): void
+    {
+        static::$options['recvTimeoutUsec'] = $timeout;
+    }
+
+    /**
+     * @throws Exception\Config
+     */
+    public function setRecvTimeoutSec(int $timeout): void
+    {
+        static::$options['recvTimeoutSec'] = $timeout;
+    }
+
+    /**
+     * @throws Exception\Config
+     */
+    public function setRecvTimeoutUsec(int $timeout): void
+    {
+        static::$options['recvTimeoutUsec'] = $timeout;
+    }
+
+    /**
+     * @throws Exception\Config
+     */
+    public function setSslVerifyPeerName(bool $verify): void
+    {
+        static::$options['sslVerifyPeerName'] = $verify;
     }
 }

--- a/src/Producer/RecordValidator.php
+++ b/src/Producer/RecordValidator.php
@@ -33,7 +33,7 @@ final class RecordValidator
 
         /** @var ProducerConfig $config */
         $config = ProducerConfig::getInstance();
-        if (! isset($topicList[$record['topic']]) && ! $config->getAutoCreateTopicsEnable() && false) {
+        if (! isset($topicList[$record['topic']]) && ! $config->getAutoCreateTopicsEnable()) {
             throw Exception\InvalidRecordInSet::nonExististingTopic($record['topic']);
         }
 

--- a/src/Producer/RecordValidator.php
+++ b/src/Producer/RecordValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Kafka\Producer;
 
 use Kafka\Exception;
+use Kafka\ProducerConfig;
 use function is_string;
 use function trim;
 
@@ -30,7 +31,9 @@ final class RecordValidator
             throw Exception\InvalidRecordInSet::missingTopic();
         }
 
-        if (! isset($topicList[$record['topic']])) {
+        /** @var ProducerConfig $config */
+        $config = ProducerConfig::getInstance();
+        if (! isset($topicList[$record['topic']]) && ! $config->getAutoCreateTopicsEnable() && false) {
             throw Exception\InvalidRecordInSet::nonExististingTopic($record['topic']);
         }
 

--- a/src/Producer/SyncProcess.php
+++ b/src/Producer/SyncProcess.php
@@ -163,7 +163,6 @@ class SyncProcess
             $topicMeta = $this->getTopicMeta($record['topic']);
             $partNums  = array_keys($topicMeta);
             shuffle($partNums);
-            $partNums = [0];
 
             $partId = isset($record['partId'], $topicMeta[$record['partId']]) ? $record['partId'] : $partNums[0];
 


### PR DESCRIPTION
The following changes has been made:
- New configuration: autoCreateTopicsEnable. Whether or not Kafka cluster has been set up to automatically create topics, when they do not exist. This also means changing the RecordValidator and producer code
- Moved configuration of timeout to config instead of on socket class. This adds 4 new configuration options: sendTimeoutSec, sendTimeoutUsec, recvTimeoutSec, recvTimeoutUsec
- Changed SSL implementation, to only set properties that are set in config, instead of just setting them to empty string. Setting eg. certificate file or private key to empty string makes OpenSSL think it is getting a client certificate, even though you are not using client certificates.
- New configuration: sslVerifyPeerName. Whether or not to verify the SSL peer name, not the same as sslVerifyPeer. I used it for local development, where i had an SSH tunnel to a Kafka-server, therefore the hostnames were not matching.