### PR TITLE
加大socket连接允许的超时时间

### DIFF
--- a/src/Kafka/Socket.php
+++ b/src/Kafka/Socket.php
@@ -156,7 +156,7 @@ class Socket
      * @param int $sendTimeoutSec
      * @param int $sendTimeoutUsec
      */
-    public function __construct($host, $port, $recvTimeoutSec = 0, $recvTimeoutUsec = 750000, $sendTimeoutSec = 0, $sendTimeoutUsec = 100000)
+    public function __construct($host, $port, $recvTimeoutSec = 5, $recvTimeoutUsec = 750000, $sendTimeoutSec = 5, $sendTimeoutUsec = 100000)
     {
         $this->host = $host;
         $this->port = $port;


### PR DESCRIPTION
超时时间加到到5s，否则部分remote consume的情况下可能会出现连接失败